### PR TITLE
#1697748890 setting up morgan logger for https 

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,8 @@
 import express from 'express';
+import fs from 'fs';
 import { urlencoded, json } from 'body-parser';
 import cors from 'cors';
+import morganLogger from 'morgan';
 import router from './routes/index';
 import logger from './utils/winston';
 import Responses from './utils/response';
@@ -10,6 +12,10 @@ const isDevelopment = config.env;
 
 const app = express();
 
+app.use(morganLogger('common', {
+  stream: fs.createWriteStream('.logs/request.log', { flags: 'a' })
+}));
+app.use(morganLogger('dev'));
 const allowedOrigins = [
   // We shall remove this URL for production
   'http://localhost',

--- a/src/utils/winston.js
+++ b/src/utils/winston.js
@@ -10,7 +10,7 @@ const logger = createLogger({
   ),
   transports: [
     new transports.Console({
-      format: simple()
+      format: simple(),
     }),
     new transports.File({ filename: '.logs/error.log', level: 'error' }),
     new transports.File({


### PR DESCRIPTION
### What does this PR do?
This PR sets up morgan for logging the HTTP requests that are made to the API
#### Description of Task to be completed?
- [x] install morgan
- [x] setup morgan middleware to log the errors using Winston logger
#### How should this be manually tested?
- git clone the repository
- run `npm install` to install the dependencies
- run `npm run watch`
- go to postman and test using endpoint `localhost:3000` 
- then check on the terminal if it has been logged
#### Any background context you want to provide?
- Winston logger is used to logging
#### What are the relevant pivotal tracker stories?
[#1697748890](https://www.pivotaltracker.com/n/projects/2407417/stories/169774890)
#### Screenshots
![image](https://user-images.githubusercontent.com/46062609/69320394-ce35ce00-0c49-11ea-8efa-82dc967cfcdb.png)


