### PR TITLE
#169257410 Builds LineManager update request to appproved or declined

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -58,7 +58,7 @@ app.use((err, req, res, next) => {
   if (isDevelopment !== 'development') {
     return next(err);
   }
-  logger.error(`${err.status || 500} - ${err.message} - ${req.originalUrl} - ${req.method} - ${
+  logger.error(`${err.statusCode || 500} - ${err.message} - ${req.originalUrl} - ${req.method} - ${
     req.ip
   } - Stack: ${err.stack}`);
 
@@ -68,7 +68,7 @@ app.use((err, req, res, next) => {
 // Production and testing error handler middleware
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res) => {
-  logger.error(`${err.status || 500} - ${err.message} - ${req.originalUrl} - ${req.method} - ${
+  logger.error(`${err.statusCode || 500} - ${err.message} - ${req.originalUrl} - ${req.method} - ${
     req.ip
   } - Stack: ${err.stack}`);
 

--- a/src/controllers/request.controller.js
+++ b/src/controllers/request.controller.js
@@ -1,5 +1,10 @@
 import Responses from '../utils/response';
-import { getAllRequest, getOneRequest, getManagerRequest } from '../services/request.service';
+import {
+  getAllRequest,
+  getOneRequest,
+  updateRequestStatus,
+  getManagerRequest
+} from '../services/request.service';
 
 /**
  * Class requests
@@ -27,8 +32,7 @@ class Requests {
    * @returns {object} successful fetched the requests
    */
   async getOne(req, res) {
-    const currentUser = res.locals.user;
-    const requests = await getOneRequest(currentUser.userId, req.params.id);
+    const requests = await getOneRequest(req.params.id);
     if (!requests) {
       return Responses.handleError(404, 'No Requests found with such id', res);
     }
@@ -45,6 +49,23 @@ class Requests {
     const currentUser = res.locals.user;
     const requests = await getManagerRequest(currentUser.userId);
     return Responses.handleSuccess(200, 'Successfully fetched the requests', res, requests);
+  }
+
+  /**
+   *
+   * @param {*} req
+   * @param {*} res
+   * @returns {object} succesful approved or rejected a request
+   */
+  async approveRequest(req, res) {
+    const { status } = req.body;
+    const { id } = req.params;
+
+    await updateRequestStatus(id, status);
+
+    const request = await getOneRequest(id);
+
+    return Responses.handleSuccess(200, `Succesfully ${status} request`, res, request);
   }
 }
 

--- a/src/middlewares/checkRequestLineManager.js
+++ b/src/middlewares/checkRequestLineManager.js
@@ -1,0 +1,15 @@
+import Responses from '../utils/response';
+import { checkUserBelongsToManager } from '../services/request.service';
+
+const requestBelongsLineManager = async (req, res, next) => {
+  const { id } = req.params;
+  const currentUser = res.locals.user;
+
+  const user = await checkUserBelongsToManager(currentUser.userId, id);
+  if (!user) {
+    return Responses.handleError(403, 'You have no access to approve or reject this request', res);
+  }
+  next();
+};
+
+export default requestBelongsLineManager;

--- a/src/routes/api/requests.route.js
+++ b/src/routes/api/requests.route.js
@@ -4,6 +4,7 @@ import requests from '../../controllers/request.controller';
 import getRequestByStatus from '../../middlewares/queryRequestByStatus';
 import catchErrors from '../../utils/helper';
 import checkRole from '../../middlewares/roleAuthorization';
+import checkRequestLineManger from '../../middlewares/checkRequestLineManager';
 
 const router = express.Router();
 
@@ -12,7 +13,6 @@ const router = express.Router();
  *
  * /request:
  *  get:
- *    security:
  *    summary: this gets all the requests from a specific user
  *    description: Takes the users token and query(optional)
  *    tags:
@@ -93,7 +93,6 @@ router.get(
  *
  * /request:
  *  get:
- *    security:
  *    summary: this gets all the requests from a specific user to the line manager
  *    description: Takes the line manager token
  *    tags:
@@ -166,13 +165,17 @@ router.get('/requests/manager', verifyUser, checkRole.checkIsManager, catchError
 /**
  * @swagger
  *
- * /request:
+ * /requests:
  *  get:
- *    security:
  *    summary: this gets single the requests from a specific user
  *    description: Takes the users token
  *    tags:
  *      - Requests
+ *    parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
  *    produces:
  *      application/json:
  *        properties:
@@ -239,5 +242,95 @@ router.get(
   verifyUser,
   catchErrors(requests.getOne)
 );
+
+
+/**
+ * @swagger
+ *
+ * /request:
+ *  patch:
+ *    summary: update users request status using line manager
+ *    description: Takes the users token
+ *    tags:
+ *      - Requests
+ *    parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
+ *    requestBody:
+ *        content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status:
+ *                  type: string
+ *    produces:
+ *      application/json:
+ *        properties:
+ *          status:
+ *            type: string
+ *          message:
+ *            type: string
+ *          data:
+ *            type: array
+ *            items:
+ *              type: object
+ *              properties:
+ *                id:
+ *                  type: integer
+ *                status:
+ *                  type: string
+ *                userId:
+ *                  type: integer
+ *                type:
+ *                   type: string
+ *                createdAt:
+ *                  type: string
+ *                updatedAt:
+ *                  type: string
+ *                trips:
+ *                  type: array
+ *                  items:
+ *                    type: object
+ *                    properties:
+ *                      id:
+ *                        type: integer
+ *                      userId:
+ *                        type: integer
+ *                      hotelId:
+ *                        type: integer
+ *                      type:
+ *                        type: string
+ *                      leavingFrom:
+ *                        type: string
+ *                      goingTo:
+ *                        type: string
+ *                      travelDate:
+ *                        type: string
+ *                      returnDate:
+ *                        type: string
+ *                      reason:
+ *                        type: string
+ *                      requestId:
+ *                        type: integer
+ *                      createdAt:
+ *                        type: string
+ *                      updatedAt:
+ *                        type: string
+ *    responses:
+ *      200:
+ *        description: success
+ *      401:
+ *        description: unauthorized
+ *      500:
+ *        description: error occurred
+ *      403:
+ *        description: can't access this request
+ *      400:
+ *        description: invalid inputs
+ */
+router.patch('/request/:id', verifyUser, checkRole.checkIsManager, checkRequestLineManger, catchErrors(requests.approveRequest));
 
 export default router;

--- a/src/tests/approveRequest.test.js
+++ b/src/tests/approveRequest.test.js
@@ -1,0 +1,108 @@
+import chaiHttp from 'chai-http';
+import { use, request, should } from 'chai';
+import app from '../app';
+import {
+  userfactory,
+  hotelfactory,
+  roomfactory
+} from './scripts/factories';
+import Hash from '../utils/hash';
+import requestData from './mock-data/request';
+import tripsData from './mock-data/trips-data';
+import tokenizer from '../utils/jwt';
+import truncate from './scripts/truncate';
+
+should();
+use(chaiHttp);
+
+const PREFIX = '/api/v1';
+
+describe('PATCH /Request/:ID appproved', () => {
+  let token = '';
+  let userToken = '';
+  let requestId = '';
+  let manager = '';
+  before(async () => {
+    await truncate();
+    await roomfactory(tripsData.rooms[0]);
+    await hotelfactory(tripsData.hotels[0]);
+    manager = await userfactory(requestData.users[0]);
+    const user = await userfactory({
+      firstName: 'new',
+      lastName: 'test',
+      email: 'testnew@email.co',
+      password: Hash.generateSync('bttj6bt'),
+      lineManagerId: manager.id
+    });
+    token = await tokenizer.signToken({
+      id: manager.id,
+      email: 'testcase@email.co',
+      role: 'manager'
+    });
+    userToken = await tokenizer.signToken(user);
+  });
+
+  before((done) => {
+    request(app)
+      .post(`${PREFIX}/trips/oneway`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send(tripsData.trips[0])
+      .end((err, res) => {
+        requestId = res.body.data.id;
+        res.status.should.be.eql(201);
+        done(err);
+      });
+  });
+
+  it('Patch /requests/manager - Manager should not be able to update status to any other than approve or reject', (done) => {
+    request(app)
+      .patch(`${PREFIX}/request/${requestId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'approv' })
+      .end((err, res) => {
+        res.status.should.be.equal(400);
+        done();
+      });
+  });
+  it('Patch /requests/manager - Manager should be able to update status to approved or declined successfully', (done) => {
+    request(app)
+      .patch(`${PREFIX}/request/${requestId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'approved' })
+      .end((err, res) => {
+        res.status.should.be.equal(200);
+        res.body.message.should.be.equal('Succesfully approved request');
+        done();
+      });
+  });
+  it('Patch /requests/manager - Manager should not be able to update status twice', (done) => {
+    request(app)
+      .patch(`${PREFIX}/request/${requestId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'declined' })
+      .end((err, res) => {
+        res.status.should.be.equal(409);
+        done();
+      });
+  });
+  describe('Manager should not be able to access Requests that do not belong to him', () => {
+    before(async () => {
+      manager = await userfactory(requestData.users[3]);
+      token = await tokenizer.signToken({
+        id: manager.id,
+        email: 'testcase@email.co',
+        role: 'manager'
+      });
+    });
+    it('Patch /request/:id - user should not be able to update request status that doesn\'t belong to him', (done) => {
+      request(app)
+        .patch(`${PREFIX}/request/1`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ status: 'approved' })
+        .end((err, res) => {
+          res.status.should.be.equal(403);
+          done();
+        });
+    });
+  });
+});

--- a/src/tests/declineRequest.test.js
+++ b/src/tests/declineRequest.test.js
@@ -1,0 +1,109 @@
+import chaiHttp from 'chai-http';
+import { use, request, should } from 'chai';
+import app from '../app';
+import {
+  userfactory,
+  hotelfactory,
+  roomfactory
+} from './scripts/factories';
+import Hash from '../utils/hash';
+import requestData from './mock-data/request';
+import tripsData from './mock-data/trips-data';
+import tokenizer from '../utils/jwt';
+import truncate from './scripts/truncate';
+
+should();
+use(chaiHttp);
+
+const prefix = '/api/v1';
+
+describe('PATCH /Request/:ID declined', () => {
+  let token = '';
+  let userToken = '';
+  let requestId = '';
+  before(async () => {
+    await truncate();
+    await roomfactory(tripsData.rooms[0]);
+    await roomfactory(tripsData.rooms[1]);
+    await hotelfactory(tripsData.hotels[0]);
+    const manager = await userfactory(requestData.users[0]);
+    const user = await userfactory({
+      firstName: 'new',
+      lastName: 'test',
+      email: 'testnew@email.co',
+      password: Hash.generateSync('bttj6bt'),
+      lineManagerId: manager.id
+    });
+    token = await tokenizer.signToken({
+      id: manager.id,
+      email: 'testcase@email.co',
+      role: 'manager'
+    });
+    userToken = await tokenizer.signToken(user);
+  });
+
+  before((done) => {
+    request(app)
+      .post(`${prefix}/trips/oneway`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send(tripsData.trips[0])
+      .end((err, res) => {
+        requestId = res.body.data.id;
+        res.status.should.be.eql(201);
+        done(err);
+      });
+  });
+
+  it('Patch /requests/manager - Manager should be able to update status to any other than approve or reject', (done) => {
+    request(app)
+      .patch(`${prefix}/request/${requestId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'declin' })
+      .end((err, res) => {
+        res.status.should.be.equal(400);
+        done();
+      });
+  });
+  it('Patch /requests/manager - Manager should be able to update status to declined successfully', (done) => {
+    request(app)
+      .patch(`${prefix}/request/${requestId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'declined' })
+      .end((err, res) => {
+        res.status.should.be.equal(200);
+        res.body.message.should.be.equal('Succesfully declined request');
+        done();
+      });
+  });
+  it('Patch /requests/manager - Manager should not be able to update status twice', (done) => {
+    request(app)
+      .patch(`${prefix}/request/${requestId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'approved' })
+      .end((err, res) => {
+        res.status.should.be.equal(409);
+        done();
+      });
+  });
+  describe('No access to the', () => {
+    before(async () => {
+      await truncate();
+      const manager = await userfactory(requestData.users[0]);
+      token = await tokenizer.signToken({
+        id: manager.id,
+        email: 'testcase@email.co',
+        role: 'manager'
+      });
+    });
+    it('Patch /request/:id - user should not be able to update request status that doesn\'t belong to him', (done) => {
+      request(app)
+        .patch(`${prefix}/request/1`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ status: 'declined' })
+        .end((err, res) => {
+          res.status.should.be.equal(403);
+          done();
+        });
+    });
+  });
+});

--- a/src/tests/editProfile.test.js
+++ b/src/tests/editProfile.test.js
@@ -1,0 +1,228 @@
+/* eslint-disable object-curly-newline */
+import chaiHttp from 'chai-http';
+import { expect, request, should, use } from 'chai';
+import app from '../app';
+import tokenizer from '../utils/jwt';
+import db from '../models';
+import testUsers from './mock-data/test-users';
+import truncate from './scripts/truncate';
+
+should();
+use(chaiHttp);
+
+const prefix = '/api/v1';
+let token,
+  userId,
+  managerId,
+  invalidManagerId,
+  userDetails,
+  userDetailsOwnManage,
+  userDetailsInvalidLineManager,
+  userDetailsUnexistingLineManager;
+describe('Update profile', () => {
+  before(async () => {
+    await truncate();
+    await db.user.destroy({ where: {}, force: true });
+    const user = (await db.user.create(testUsers[0]));
+    const manager = (await db.user.create(testUsers[1]));
+    const invalidManager = (await db.user.create(testUsers[4]));
+    userId = user.id;
+    managerId = manager.id;
+    invalidManagerId = invalidManager.id;
+    await db.user.update({ role: 'manager' }, { where: { id: managerId } });
+
+    token = await tokenizer.signToken({
+      userId,
+      email: 'john@barefoot.com',
+      isVerified: true
+    });
+
+    token = `Bearer ${token}`;
+
+    userDetails = {
+      firstName: 'Johnny',
+      lastName: 'Doey',
+      password: 'newPassword8',
+      email: 'john@barefoot.com',
+      phoneNumber: '000-000-0012',
+      lineManagerId: managerId,
+      gender: 'male',
+      preferredLanguage: 'english',
+      preferredCurrency: '$',
+      department: 'IT',
+      birthDate: '1950-01-01T00:00:00.000Z',
+      residenceAddress: 'Kigali, Rwanda'
+    };
+
+    userDetailsOwnManage = {
+      firstName: 'Johnny',
+      lastName: 'Doey',
+      password: 'newPassword8',
+      email: 'john@barefoot.com',
+      phoneNumber: '000-000-0012',
+      lineManagerId: userId,
+      gender: 'male',
+      preferredLanguage: 'english',
+      preferredCurrency: '$',
+      department: 'IT',
+      birthDate: '1950-01-01T00:00:00.000Z',
+      residenceAddress: 'Kigali, Rwanda'
+    };
+
+    userDetailsInvalidLineManager = {
+      firstName: 'Johnny',
+      lastName: 'Doey',
+      password: 'newPassword8',
+      email: 'john@barefoot.com',
+      phoneNumber: '000-000-0012',
+      lineManagerId: invalidManagerId,
+      gender: 'male',
+      preferredLanguage: 'english',
+      preferredCurrency: '$',
+      department: 'IT',
+      birthDate: '1950-01-01T00:00:00.000Z',
+      residenceAddress: 'Kigali, Rwanda'
+    };
+
+    userDetailsUnexistingLineManager = {
+      firstName: 'Johnny',
+      lastName: 'Doey',
+      password: 'newPassword8',
+      email: 'john@barefoot.com',
+      phoneNumber: '000-000-0012',
+      lineManagerId: 2000,
+      gender: 'male',
+      preferredLanguage: 'english',
+      preferredCurrency: '$',
+      department: 'IT',
+      birthDate: '1950-01-01T00:00:00.000Z',
+      residenceAddress: 'Kigali, Rwanda'
+    };
+  });
+
+  describe('/PATCH api/v1/user/update-profile', () => {
+    it('it should return a 201 response upon authorization', (done) => {
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .set('Authorization', token)
+        .send(userDetails)
+        .end((err, res) => {
+          expect(res.status).eql(201);
+          done();
+        });
+    });
+
+
+    it('it should return a 409 response when he sets him as own lineManager', (done) => {
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .set('Authorization', token)
+        .send(userDetailsOwnManage)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(409);
+          done();
+        });
+    });
+
+    it('it should return a 409 response by setting a LineManager with no "manager" role', (done) => {
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .set('Authorization', token)
+        .send(userDetailsInvalidLineManager)
+        .end((_err, res) => {
+          expect(res.status)
+            .eql(409);
+          done();
+        });
+    });
+
+    it('it should return a 409 response by setting a LineManager with unexisting user', (done) => {
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .set('Authorization', token)
+        .send(userDetailsUnexistingLineManager)
+        .end((_err, res) => {
+          expect(res.status)
+            .eql(409);
+          done();
+        });
+    });
+
+    it('it should return a 401 response without authorization', (done) => {
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .send(userDetails)
+        .end((_err, res) => {
+          expect(res.status)
+            .eql(401);
+          done();
+        });
+    });
+
+    it('it should return error for an invalid token', (done) => {
+      const invalidToken = 'Bearer eyJhbGciOib20iLCJpYXQiOjE1NjgzOTA3gJ8KbmH4eJwNQiAHdYH-wlyU';
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .set('Authorization', invalidToken)
+        .send(userDetails)
+        .end((err, res) => {
+          expect(res.status).eql(401);
+          done();
+        });
+    });
+  });
+
+  describe('/GET api/v1/user/:userId', () => {
+    it('it should return a 200 response upon authorization', (done) => {
+      request(app)
+        .get(`${prefix}/user/${userId}`)
+        .set('Authorization', token)
+        .end((_err, res) => {
+          expect(res.status).eql(200);
+          done();
+        });
+    });
+
+    it('it should return a 404 response when the user was not found', (done) => {
+      request(app)
+        .get(`${prefix}/user/2000`)
+        .set('Authorization', token)
+        .end((_err, res) => {
+          expect(res.status)
+            .eql(404);
+          done();
+        });
+    });
+
+    it('it should return a 422 response if the userId is invalid', (done) => {
+      request(app)
+        .get(`${prefix}/user/ERRONOUS**ID`)
+        .set('Authorization', token)
+        .end((_err, res) => {
+          expect(res.status).eql(422);
+          done();
+        });
+    });
+
+    it('it should return a 401 response without authorization', (done) => {
+      request(app)
+        .get(`${prefix}/user/${userId}`)
+        .end((_err, res) => {
+          expect(res.status).eql(401);
+          done();
+        });
+    });
+
+    it('it should return error for an invalid token', (done) => {
+      const invalidToken = 'Bearer eyJhbGciOib20iLCJpYXQiOjE1NjgzOTA3gJ8KbmH4eJwNQiAHdYH-wlyU';
+      request(app)
+        .get(`${prefix}/user/${userId}`)
+        .set('Authorization', invalidToken)
+        .end((err, res) => {
+          expect(res.status).eql(401);
+          done();
+        });
+    });
+  });
+});

--- a/src/tests/mock-data/request.js
+++ b/src/tests/mock-data/request.js
@@ -22,7 +22,14 @@ const request = {
       email: 'testnew@email.co',
       password: Hash.generateSync('bttj6bt'),
       lineManagerId: 2
-    }
+    },
+    {
+      firstName: 'Test',
+      lastName: 'case',
+      email: 'testcase1@email.co',
+      password: Hash.generateSync('fghtttfht55'),
+      role: 'manager'
+    },
   ]
 };
 

--- a/src/tests/units/utils/error.test.js
+++ b/src/tests/units/utils/error.test.js
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import ErrorHandler from '../../../utils/error';
+
+describe('Error handler constructor', () => {
+  it('should be able throw an error when called', (done) => {
+    const fcn = () => { throw new ErrorHandler('Invalid details'); };
+    expect(fcn).to.throw(Error, 'Invalid details');
+    done();
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Line managers should be to approve or decline their direct report users' requests that are open.
#### Description of Task to be completed?
- [x] check the request, if the line manager can approve
- [x] check if the status requested to update exists
- [x]  check if the request has already been approved or declined
- [x] approve or decline the request successful
#### How should this be manually tested?
- git clone this branch
- run `npm install` to install dependencies 
- run `npm run migrate:undo` and `npm run migrate` to build the tables
- run `npm run watch` to start the server
- run signup two users with the data on the `POST {{url}}/api/v1/auth/signup`
- update one user to be a manager by using `Patch {{url}}/api/v1/auth/user/role`
- update the user using the line manager id `Patch {{url}}/api/v1/user/update-profile`
- using the user token create a trip
- using line manager token get the trips using endpoint `Patch {{url}}/api/v1/request/:id` and use `{ "status": "approved" }` to approve or `{ "status": "declined" }` to decline
#### Any background context you want to provide?
- set the line manager on the user before approving
- [implementation plan](https://docs.google.com/document/d/1M81hCB_qAQhr37Dt_K90FHjeO6v5FCQD9jRyvdS1zvQ/edit?usp=sharing)
#### What are the relevant pivotal tracker stories?
[#169257410](https://www.pivotaltracker.com/n/projects/2407417/stories/169257410)

#### Questions:
- Should the status to be update be passed on the `req.query` or `req.body`?
