### PR TITLE
#169257432 Most travelled destinations

### DIFF
--- a/src/controllers/hotels.controller.js
+++ b/src/controllers/hotels.controller.js
@@ -3,15 +3,17 @@ import locationService from '../services/location.service';
 import filesService from '../services/files.service';
 import Responses from '../utils/response';
 import roomService from '../services/room.service';
+import { getAllRequestsHotels } from '../services/request.service';
+
 /**
  * Class for accomodation facilities
  */
 class Hotel {
   /**
-     * Creates hotel
-     * @param {*} req
-     * @param {*} res
-     * @returns {Object} response
+   * Creates hotel
+   * @param {*} req
+   * @param {*} res
+   * @returns {Object} response
      */
   async createHotel(req, res) {
     const {
@@ -206,6 +208,61 @@ class Hotel {
     const hotel = await hotelService.getHotelById(hotelId, userId);
 
     return Responses.handleSuccess(200, `${action} successful`, res, hotel);
+  }
+
+  /**
+   * @param {object} req
+   * @param {object} res
+   * @returns {object} responses
+   */
+  async getMostVisitedDestination(req, res) {
+    const results = [];
+    const requestsTrips = await getAllRequestsHotels();
+
+    if (!requestsTrips.length) {
+      return Responses.handleError(404, 'There is no past travel yet.', res);
+    }
+
+    const counter = {};
+    let trips = [];
+
+    for (let i = 0; i < requestsTrips.length; i += 1) {
+      trips = trips.concat(requestsTrips[i].trips);
+    }
+
+    for (let i = 0; i < trips.length; i += 1) {
+      const el = trips[i].hotel.id;
+
+      if (counter[el] === undefined) {
+        counter[el] = 0;
+      }
+      counter[el] += 1;
+    }
+
+    const sortedTrips = [];
+
+    // eslint-disable-next-line guard-for-in,no-restricted-syntax
+    for (const element in counter) {
+      sortedTrips.push([element, counter[element]]);
+    }
+    sortedTrips.sort((a, b) => a[1] - b[1]);
+    const keys = sortedTrips.map(sortableItem => sortableItem[0]);
+
+    const hotels = await hotelService.mostTravelled(keys);
+
+    for (let i = 0; i < sortedTrips.length; i += 1) {
+      const hotel = hotels.find(item => `${item.id}` === sortedTrips[i][0]);
+      results.unshift({
+        count: sortedTrips[i][1],
+        hotel,
+      });
+    }
+
+    return Responses.handleSuccess(
+      200,
+      'Most travelled destinations listed successfully',
+      res, { results },
+    );
   }
 }
 

--- a/src/routes/api/hotels.route.js
+++ b/src/routes/api/hotels.route.js
@@ -7,7 +7,6 @@ import authorize from '../../middlewares/roleAuthorization';
 import { verifyUser } from '../../middlewares/checkToken';
 import checkHotel from '../../middlewares/checkHotel';
 
-
 const router = express.Router();
 
 /**
@@ -151,7 +150,7 @@ router.post(
   authorize(['travel_administrator', 'super_administrator']),
   fileService.upload('image'),
   validation,
-  catchErrors(hotels.addRoom)
+  catchErrors(hotels.addRoom),
 );
 
 /**
@@ -415,3 +414,26 @@ router.get(
   catchErrors(hotels.getAllHotels)
 );
 export default router;
+
+/**
+ * @swagger
+ *
+ * /api/v1/hotels/most-travelled:
+ *   post:
+ *     tags:
+ *       - Hotels
+ *     summary: Get the most visited Hotel
+ *     description: Allow user to get the most travelled destination
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Successfully retrieved the most travelled destination
+ *       '404':
+ *         description: Trips not found
+ */
+router.get(
+  '/hotels/most-travelled',
+  verifyUser,
+  catchErrors(hotels.getMostVisitedDestination),
+);

--- a/src/services/hotel.service.js
+++ b/src/services/hotel.service.js
@@ -190,6 +190,25 @@ class HotelService {
 
     return hotels;
   }
+
+  /**
+   * Get most travelled destinations
+   * @param {Array} arr
+   * @returns {Array} hotels
+   */
+  async mostTravelled(arr) {
+    const { hotel } = db;
+    const { Op } = Sequelize;
+    const mostTravelled = await hotel.findAll({
+      where: {
+        id: {
+          [Op.in]: arr,
+        },
+      },
+    });
+
+    return mostTravelled;
+  }
 }
 
 export default new HotelService();

--- a/src/services/request.service.js
+++ b/src/services/request.service.js
@@ -271,6 +271,36 @@ const getUserTripsStats = async ({ user, fromDate, req }) => {
   return requests;
 };
 
+const getAllRequestsHotels = async () => {
+  const { trip, hotel, request, } = db;
+
+  const requests = await request.findAll({
+    where: {
+      status: 'approved',
+    },
+    include: [
+      {
+        model: trip,
+        as: 'trips',
+        where: {
+          travelDate: {
+            [Op.lt]: (new Date()).toISOString().split('T')[0],
+          },
+        },
+        include: [
+          {
+            model: hotel,
+            as: 'hotel',
+          },
+        ],
+      },
+    ],
+    attributes: [],
+  });
+
+  return requests;
+};
+
 export {
   createRequest,
   getRequestbyStatus,
@@ -282,4 +312,5 @@ export {
   checkUserBelongsToManager,
   getSearchedRequests,
   getUserTripsStats,
+  getAllRequestsHotels
 };

--- a/src/tests/mock-data/most-visited.js
+++ b/src/tests/mock-data/most-visited.js
@@ -1,0 +1,64 @@
+import Hash from '../../utils/hash';
+
+export default {
+  users: [
+    {
+      id: 1,
+      firstName: 'Test',
+      lastName: 'case',
+      email: 'testcase@email.co',
+      password: Hash.generateSync('fghtttfht55'),
+      role: 'manager',
+    },
+    {
+      id: 2,
+      firstName: 'John',
+      lastName: 'McCain',
+      password: Hash.generateSync('1234567e'),
+      email: 'john@mccain.com',
+      lineManagerId: 1,
+    }
+  ],
+  locations: [
+    {
+      id: 1,
+      country: 'Rwanda',
+      city: 'kigali',
+    }
+  ],
+  hotels: [
+    {
+      id: 1,
+      locationId: 1,
+      name: 'Test hotel',
+      image: '',
+      street: 'kk 127',
+      description: 'best ever hotel',
+      services: 'service 1, service 2',
+      userId: 1,
+    }
+  ],
+  rooms: [
+    {
+      id: 1,
+      hotelId: 1,
+      name: 'Muhabura',
+      type: 'return',
+      description: 'The best room ever',
+      image: 'room.png',
+      cost: 5000,
+      status: 'available',
+    }
+  ],
+  trips: [
+    {
+      leavingFrom: 'Kigali',
+      goingTo: 'Nairobi',
+      travelDate: '2019-11-18',
+      reason: 'visit our agents',
+      hotelId: 1,
+      type: 'return',
+      rooms: [1],
+    }
+  ]
+};

--- a/src/tests/mostVisitedDestinations.test.js
+++ b/src/tests/mostVisitedDestinations.test.js
@@ -1,0 +1,75 @@
+import { expect, request, use } from 'chai';
+import chaiHttp from 'chai-http';
+import truncate from './scripts/truncate';
+import tokenizer from '../utils/jwt';
+import mostVisitedData from './mock-data/most-visited';
+import app from '../app';
+import db from '../models';
+
+use(chaiHttp);
+
+describe('Most travel destinations', () => {
+  const prefix = '/api/v1';
+  let userToken, hotelId, roomId;
+
+  before(async () => {
+    await db.like.destroy({ where: {}, force: true });
+    await truncate();
+    await db.user.create(mostVisitedData.users[0]);
+    await db.location.create(mostVisitedData.locations[0]);
+
+    const currentUser = await db.user.create(mostVisitedData.users[1]);
+
+    hotelId = (await db.hotel.create(mostVisitedData.hotels[0])).id;
+    roomId = (await db.room.create(mostVisitedData.rooms[0])).id;
+    userToken = await tokenizer.signToken(currentUser);
+  });
+
+  describe('If there are no past trips', () => {
+    it(
+      'should throw error with no previous trips',
+      (done) => {
+        request(app)
+          .get(`${prefix}/hotels/most-travelled`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .end((err, res) => {
+            expect(res.status).to.eq(404);
+            done(err);
+          });
+      },
+    );
+  });
+  describe('If there are some past trips', () => {
+    before((done) => {
+      request(app)
+        .post(`${prefix}/trips/oneway`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({
+          leavingFrom: 'Kigali',
+          goingTo: 'Nairobi',
+          travelDate: '2019-11-18',
+          reason: 'visit our agents',
+          hotelId,
+          type: 'return',
+          rooms: [roomId],
+        })
+        .end(async (err, res) => {
+          await db.request.update(
+            { status: 'approved' },
+            { where: { id: res.body.data.id } },
+          );
+          done();
+        });
+    });
+
+    it('should show Most travelled destination', (done) => {
+      request(app)
+        .get(`${prefix}/hotels/most-travelled`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .end((err, res) => {
+          expect(res.status).to.eq(200);
+          done(err);
+        });
+    });
+  });
+});

--- a/src/tests/scripts/factories.js
+++ b/src/tests/scripts/factories.js
@@ -11,23 +11,28 @@ const messageFactory = async (data) => {
 };
 
 const hotelfactory = async (data) => {
-  await db.hotel.create(data);
+  const hotel = await db.hotel.create(data);
+  return hotel;
 };
 
 const roomfactory = async (data) => {
-  await db.room.create(data);
+  const room = await db.room.create(data);
+  return room;
 };
 
 const tripfactory = async (data) => {
-  await db.room.create(data);
+  const trip = await db.room.create(data);
+  return trip;
 };
 
 const locationfactory = async (data) => {
-  await db.location.create(data);
+  const location = await db.location.create(data);
+  return location;
 };
 
 const requestfactory = async (data) => {
-  await db.request.create(data);
+  const request = await db.request.create(data);
+  return request;
 };
 
 const likesfactory = async (data) => {

--- a/src/tests/units/controllers/authController.test.js
+++ b/src/tests/units/controllers/authController.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-unused-vars */
 /* eslint-disable import/no-extraneous-dependencies */


### PR DESCRIPTION
#### What does this PR do?
Lets the users be able to get info on the most frequently travelled centre/destination
#### Description of Task to be completed?
- writing tests to test the feature's functionality
- create a route to get the most travelled destination `GET /api/v1/hotels/most-travelled`
- make the hotels (destination) controller
- make a hotels service to fetch the most travelled destinations
#### How should this be manually tested?
- clone the project locally
- install the dependencies `npm install`
- run the migration `npm run migrate`
- by going to the route: `GET /api/v1/hotels/most-travelled` you should get a message that ` There are no past travel yet.`
- But after creating a one-way trip and hitting the route: `GET /api/v1/hotels/most-travelled`, the hotel linked to the created trip will be shown as the most visited destination
#### Any background context you want to provide?
- As the most visited destinations are the places (hotels) visited in the past, the corresponding request has to be a request with status `approved`.
#### What are the relevant pivotal tracker stories?
#169257432
#### Screenshots (if appropriate)
1. If no trip request was approved in the past, there will be no travelled destination
![image](https://user-images.githubusercontent.com/3137192/70429297-f3677080-1a80-11ea-9dc0-ff1a50d56a87.png)

2. List of most visited destinations with their count.
![image](https://user-images.githubusercontent.com/3137192/70431144-0c722080-1a85-11ea-875f-fe7e0ba7824e.png)
#### Questions:
N/A
