### PR TITLE
#169257421 Users should be able notified if comments are made on their requests

### DIFF
--- a/src/controllers/comments.controller.js
+++ b/src/controllers/comments.controller.js
@@ -1,5 +1,7 @@
 import Responses from '../utils/response';
 import CommentService from '../services/Comment.service';
+import NotificationService from '../services/notification.service';
+import NotificationUtil from '../utils/notification.util';
 
 const { postRequestComment, deleteCommentById } = CommentService;
 
@@ -21,7 +23,15 @@ class CommentsController {
 
     const commentData = await postRequestComment(userId, requestId, comment);
 
-    Responses.handleSuccess(201, 'Comment posted successfully', res, commentData.dataValues);
+    const notification = await NotificationService.createNotification({
+      requestId,
+      messages: 'New comment posted on your request',
+      type: 'new_comment',
+      userId: commentData.user,
+    });
+    NotificationUtil.echoNotification(req, notification, 'new_comment', commentData.user);
+
+    Responses.handleSuccess(201, 'Comment posted successfully', res, commentData);
   }
 
   /**

--- a/src/controllers/trips.controller.js
+++ b/src/controllers/trips.controller.js
@@ -33,6 +33,7 @@ class Trip {
 
     const requestId = await createRequest(currentUser.userId, 'single');
 
+
     tripService.create({
       hotelId,
       type,
@@ -60,7 +61,8 @@ class Trip {
 
     const { lineManager } = currentUser;
     const notification = await NotificationService.createNotification({
-      modelName: 'Request',
+      requestId,
+      messages: 'New Travel Requested',
       type: 'new_request',
       userId: lineManager,
     });
@@ -88,7 +90,6 @@ class Trip {
         leavingFrom,
         goingTo,
         travelDate,
-        returnDate,
         reason,
         rooms
       } = travel;
@@ -99,7 +100,6 @@ class Trip {
         leavingFrom,
         goingTo,
         travelDate,
-        returnDate,
         reason,
         rooms,
         requestId,

--- a/src/migrations/20191210092017-modify-notifications-table.js
+++ b/src/migrations/20191210092017-modify-notifications-table.js
@@ -1,0 +1,30 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => Promise.all([
+    queryInterface.removeColumn('notifications', 'modelName'),
+    queryInterface.addColumn(
+      'notifications',
+      'requestId',
+      {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        onDelete: 'CASCADE',
+        references: {
+          model: 'requests',
+          key: 'id',
+        },
+      }
+    ),
+    queryInterface.addColumn(
+      'notifications',
+      'messages',
+      {
+        allowNull: false,
+        type: Sequelize.STRING,
+      }
+    ),
+  ]),
+  down: async (queryInterface) => Promise.all([
+    queryInterface.removeColumn('notifications', 'requestId'),
+    queryInterface.removeColumn('notifications', 'messages'),
+  ])
+};

--- a/src/models/Notification.js
+++ b/src/models/Notification.js
@@ -1,21 +1,30 @@
 module.exports = (sequelize, DataTypes) => {
   const Notification = sequelize.define('notification', {
-    modelName: DataTypes.STRING,
+    userId: DataTypes.INTEGER,
     type: {
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
         isIn: {
-          args: [['new_request', 'request_approved']],
+          args: [['new_request', 'request_approved', 'new_comment']],
           msg: 'Invalid value',
         },
       },
     },
-    isRead: DataTypes.BOOLEAN
+    messages: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    isRead: DataTypes.BOOLEAN,
+    requestId: DataTypes.INTEGER
   }, {});
   Notification.associate = (models) => {
     Notification.belongsTo(models.user, {
       foreignKey: 'userId',
+      targetKey: 'id',
+    });
+    Notification.belongsTo(models.request, {
+      foreignKey: 'requestId',
       targetKey: 'id',
     });
   };

--- a/src/models/Request.js
+++ b/src/models/Request.js
@@ -35,6 +35,10 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'requestId',
       onDelete: 'CASCADE'
     });
+    Request.hasMany(models.notification, {
+      foreignKey: 'requestId',
+      onDelete: 'CASCADE'
+    });
   };
   return Request;
 };

--- a/src/services/Comment.service.js
+++ b/src/services/Comment.service.js
@@ -34,11 +34,18 @@ class CommentService {
     }
 
     // eslint-disable-next-line no-return-await
-    return await db.comment.create({
+    const rawComments = await db.comment.create({
       userId,
       comment,
       requestId
     });
+
+    const checkUserNotified = userId === lineManagerId ? request.userId : lineManagerId;
+    const comments = rawComments.get({ plain: true });
+    return {
+      ...comments,
+      user: checkUserNotified
+    };
   }
 
   /**

--- a/src/tests/comments.test.js
+++ b/src/tests/comments.test.js
@@ -12,7 +12,16 @@ use(chaiHttp);
 
 describe('Travel request comments', () => {
   const prefix = '/api/v1';
-  let rightUserToken, wrongUserToken, requestId, commentExample, manager;
+  let rightUserToken,
+    managerToken,
+    wrongUserToken,
+    requestId,
+    commentExample,
+    manager,
+    rightUser,
+    wrongUser,
+    commentId,
+    othersComment;
 
   before(async () => {
     await truncate();
@@ -21,14 +30,14 @@ describe('Travel request comments', () => {
     await roomfactory(tripsData.rooms[2]);
     await hotelfactory(tripsData.hotels[0]);
     manager = await userfactory(requestData.users[0]);
-    const rightUser = await db.user.create({
+    rightUser = await db.user.create({
       firstName: 'John',
       lastName: 'Doe',
       password: '12345678',
       email: 'john@barefoot.com',
       lineManagerId: manager.id
     });
-    const wrongUser = await db.user.create({
+    wrongUser = await db.user.create({
       firstName: 'Eric',
       lastName: 'Doe',
       password: '12345678',
@@ -49,6 +58,8 @@ describe('Travel request comments', () => {
       email: wrongUser.email,
       isVerified: 1
     });
+
+    managerToken = await tokenizer.signToken(manager);
   });
 
   before((done) => {
@@ -67,6 +78,18 @@ describe('Travel request comments', () => {
       request(app)
         .post(`/api/v1/requests/${requestId}/comment`)
         .set('Authorization', `Bearer ${rightUserToken}`)
+        .send(commentExample)
+        .end((_err, res) => {
+          expect(res.status)
+            .eql(201);
+          done();
+        });
+    });
+
+    it('should allow the owner of the request to comment successfully', (done) => {
+      request(app)
+        .post(`/api/v1/requests/${requestId}/comment`)
+        .set('Authorization', `Bearer ${managerToken}`)
         .send(commentExample)
         .end((_err, res) => {
           expect(res.status)
@@ -96,6 +119,69 @@ describe('Travel request comments', () => {
           expect(res.status)
             .eql(404);
           done();
+        });
+    });
+  });
+
+  before(async () => {
+    const comment = await db.comment.create({
+      requestId,
+      userId: rightUser.id,
+      comment: 'This is an example comment!',
+      isVisible: true,
+    });
+    commentId = await comment.id;
+
+    othersComment = await db.comment.create({
+      requestId,
+      userId: manager.id,
+      comment: 'Another comment!',
+      isVisible: true
+    });
+  });
+
+  describe(`PATCH ${prefix}/comments/:commentId/delete`, async () => {
+    it('should allow the owner of the request to delete the comment successfully', (done) => {
+      request(app)
+        .patch(`${prefix}/comments/${commentId}/delete`)
+        .set('Authorization', `Bearer ${rightUserToken}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(200);
+          done(err);
+        });
+    });
+
+    it('should not allow other than the owner of the request to delete the comment', (done) => {
+      request(app)
+        .patch(`${prefix}/comments/${othersComment.id}/delete`)
+        .set('Authorization', `Bearer ${rightUserToken}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(403);
+          done(err);
+        });
+    });
+
+    it('should throw a not found exception when comment is missing', (done) => {
+      request(app)
+        .patch(`${prefix}/comments/30000000/delete`)
+        .set('Authorization', `Bearer ${rightUserToken}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(404);
+          done(err);
+        });
+    });
+
+    it('should throw an already deleted exception when comment was already deleted', (done) => {
+      request(app)
+        .patch(`${prefix}/comments/${commentId}/delete`)
+        .set('Authorization', `Bearer ${rightUserToken}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(403);
+          done(err);
         });
     });
   });


### PR DESCRIPTION
#### What does this PR do?
It notifies the users when any comments are made on their requests
#### Description of Task to be completed?
- [x] add send a comment to the user.
- [x] fix comment tests
- [x] send to users the comments using sockets
#### How should this be manually tested?
- git clone the repo
- run `npm install` to install dependencies
- run `npm run migrate` to run the new migrations
- run `npm run pretest-travis` to run the migration for tests
- run `npm test` to run the tests
- run the seeders using `npx sequelize-cli db:seed:all `
- go to postman
- use login the requestor with login `{ "email": "requester@user.com", "password": "12345678" }` and line manager `{ "email": "line@manager.com", "password": "12345678" }`
- assign the line manager to the requestor by updating their profile.
- create a request using the requestor
- comment on the requestors
- the comments notification will be emitted to the sockets
#### Any background context you want to provide?
- depends on `socket.io`
- [Implementation plan](https://docs.google.com/document/d/14-hAS6XPRoGJK9NDVO1do0ecA1AYCqG_oFyXkzzSXvM/edit?usp=sharing)
- front-end the functionality can be tested here is the link to the [codepen](https://codepen.io/b0nbon1/pen/oNgxbQE) 
#### What are the relevant pivotal tracker stories?
[#169257421](https://www.pivotaltracker.com/n/projects/2407417/stories/169257421)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/46062609/70593199-caf88700-1be4-11ea-8fe9-b6efde3ffb41.png)

![image](https://user-images.githubusercontent.com/46062609/70546821-a36bd500-1b78-11ea-90e9-f9b696c07e85.png)
