### PR TITLE
#170278360 removes a return in error handler middleware

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -82,7 +82,7 @@ app.use((req, res) => Responses.handleError(404, 'Route not found', res));
 // development error handler middleware
 app.use((err, req, res, next) => {
   if (isDevelopment !== 'development') {
-    return next(err);
+    next(err);
   }
   logger.error(`${err.statusCode || 500} - ${err.message} - ${req.originalUrl} - ${req.method} - ${
     req.ip


### PR DESCRIPTION
#### What does this PR do?
Fixes the error handler middleware not working on the production
#### Description of Task to be completed?
- [x] remove error return on the error handler middleware
#### How should this be manually tested?
- git clone the repo
- run `npm install`
- run `npm run pretest-travis`
- run `npm test`
#### Any background context you want to provide?
- The errors were not being caught on production the `next()` had a return
#### What are the relevant pivotal tracker stories?
- [#170278360](https://www.pivotaltracker.com/n/projects/2407417/stories/170278360)
#### Screenshots:
fixes this error output
![image](https://user-images.githubusercontent.com/46062609/70792374-c4633e80-1da1-11ea-9913-1648d1c40e08.png)
to this:

![image](https://user-images.githubusercontent.com/46062609/70792412-dd6bef80-1da1-11ea-94fd-f4380dad2519.png)


