### PR TITLE
#170276566 Use GET instead of POST in the search functionality

### DIFF
--- a/src/controllers/request.controller.js
+++ b/src/controllers/request.controller.js
@@ -86,7 +86,7 @@ class Requests {
    */
   async searchRequests(req, res) {
     const currentUser = res.locals.user;
-    const requests = await getSearchedRequests(currentUser.userId, req.body);
+    const requests = await getSearchedRequests(currentUser.userId, req.query);
     return Responses.handleSuccess(200, 'successfully retrieved search results', res, requests);
   }
 }

--- a/src/routes/api/requests.route.js
+++ b/src/routes/api/requests.route.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { verifyUser } from '../../middlewares/checkToken';
-import { validation } from '../../validation/validation';
+import { validateSearch } from '../../validation/validation';
 import requests from '../../controllers/request.controller';
 import getRequestByStatus from '../../middlewares/queryRequestByStatus';
 import catchErrors from '../../utils/helper';
@@ -337,7 +337,7 @@ router.patch('/request/:id', verifyUser, authorize(['manager']), catchErrors(che
 /**
  * @swagger
  *
- * /requests/search:
+ * /search/requests:
  *  post:
  *    security:
  *    summary: this gets searched requests from a specific user
@@ -403,10 +403,10 @@ router.patch('/request/:id', verifyUser, authorize(['manager']), catchErrors(che
  *      404:
  *        description: no matching records found
  */
-router.post(
-  '/requests/search',
+router.get(
+  '/search/requests',
   verifyUser,
-  validation,
+  validateSearch,
   catchErrors(requests.searchRequests)
 );
 

--- a/src/services/hotel.service.js
+++ b/src/services/hotel.service.js
@@ -38,6 +38,7 @@ class HotelService {
         'image',
         'description',
         'street',
+        'average_rating',
         'services',
         'createdAt',
         [Sequelize.literal(`(

--- a/src/services/request.service.js
+++ b/src/services/request.service.js
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-destructuring */
 import db from '../models';
 import ErrorHandler from '../utils/error';
 
@@ -139,19 +140,21 @@ const updateRequestStatus = async (requestId, status) => {
   throw new ErrorHandler('Please set status to "approved" or "declined"', 400);
 };
 
-const getSearchedRequests = async (userId, body) => {
-  let { searchString } = body;
+const getSearchedRequests = async (userId, query) => {
+  let { searchString } = query;
   let travelDate, returnDate;
 
-  if (Object.prototype.hasOwnProperty.call(body, 'travelDate') === false) {
+  if (Object.prototype.hasOwnProperty.call(query, 'travelDate') === false) {
     travelDate = new Date('1970-01-01');
   } else {
-    travelDate = body.travelDate;
+    travelDate = query.travelDate;
+    ({ travelDate } = query);
   }
-  if (Object.prototype.hasOwnProperty.call(body, 'returnDate') === false) {
+  if (Object.prototype.hasOwnProperty.call(query, 'returnDate') === false) {
     returnDate = new Date('9999-12-31');
   } else {
-    returnDate = body.returnDate;
+    returnDate = query.returnDate;
+    ({ returnDate } = query);
   }
 
   searchString = searchString.toLowerCase();

--- a/src/tests/hotelRatings.test.js
+++ b/src/tests/hotelRatings.test.js
@@ -8,7 +8,7 @@ should();
 use(chaiHttp);
 
 const prefix = '/api/v1';
-let requesterToken, initialRating, testHotel, unVerifiedUserToken, nonResidentUserToken;
+let requesterToken, hotelResult, testHotel, unVerifiedUserToken, nonResidentUserToken;
 
 describe(('Hotels rating testing'), () => {
   before(async () => {
@@ -20,36 +20,36 @@ describe(('Hotels rating testing'), () => {
   });
 
   it(('it fails to post hotel rating if user has not verified email'), async () => {
-    initialRating = await request(app)
+    hotelResult = await request(app)
       .post(`${prefix}/hotels/${testHotel.id}/rating`)
       .set('Authorization', unVerifiedUserToken)
       .send({
         rating: 3
       });
-    expect(initialRating.status).eql(401);
-    expect(initialRating.body.message).eql('Please verify your account through the confirmation email sent to you on registration');
+    expect(hotelResult.status).eql(401);
+    expect(hotelResult.body.message).eql('Please verify your account through the confirmation email sent to you on registration');
   });
 
   it(('it fails to post hotel rating if user has not had a trip posted under the subject hotel'), async () => {
-    initialRating = await request(app)
+    hotelResult = await request(app)
       .post(`${prefix}/hotels/${testHotel.id}/rating`)
       .set('Authorization', nonResidentUserToken)
       .send({
         rating: 3
       });
-    expect(initialRating.status).eql(401);
-    expect(initialRating.body.message).eql('You can only rate a hotel you have stayed at on a trip');
+    expect(hotelResult.status).eql(401);
+    expect(hotelResult.body.message).eql('You can only rate a hotel you have stayed at on a trip');
   });
 
   it(('it successfully returns a newly entered hotel rating'), async () => {
-    initialRating = await request(app)
+    hotelResult = await request(app)
       .post(`${prefix}/hotels/${testHotel.id}/rating`)
       .set('Authorization', requesterToken)
       .send({
         rating: 3
       });
-    expect(initialRating.status).eql(201);
-    expect(initialRating.body.message).eql('Hotel rated successfully');
+    expect(hotelResult.status).eql(201);
+    expect(hotelResult.body.message).eql('Hotel rated successfully');
   });
 
   it(('it fails to post a duplicate hotel rating'), async () => {
@@ -63,7 +63,7 @@ describe(('Hotels rating testing'), () => {
   });
 
   it(('it fails to allow another user change your rating'), async () => {
-    const ratingId = initialRating.body.data[0].id;
+    const ratingId = hotelResult.body.data[0].id;
     const res = await request(app)
       .patch(`${prefix}/rating/${ratingId}`)
       .set('Authorization', nonResidentUserToken)
@@ -81,7 +81,7 @@ describe(('Hotels rating testing'), () => {
   });
 
   it(('it successfully returns an updated hotel rating'), async () => {
-    const ratingId = initialRating.body.data[0].id;
+    const ratingId = hotelResult.body.data[0].id;
     const res = await request(app)
       .patch(`${prefix}/rating/${ratingId}`)
       .set('Authorization', requesterToken)
@@ -92,7 +92,7 @@ describe(('Hotels rating testing'), () => {
   });
 
   it(('it successfully returns a hotel rating'), async () => {
-    const ratingId = initialRating.body.data[0].id;
+    const ratingId = hotelResult.body.data[0].id;
     const res = await request(app)
       .get(`${prefix}/rating/${ratingId}`)
       .set('Authorization', requesterToken);

--- a/src/tests/searchRequests.test.js
+++ b/src/tests/searchRequests.test.js
@@ -8,68 +8,65 @@ should();
 use(chaiHttp);
 
 const prefix = '/api/v1';
-let requesterToken;
+let requesterToken, res, searchString, travelDate, returnDate;
 
-describe(('/GET /requests/search'), () => {
+describe(('/GET /search/requests'), () => {
   before(async () => {
     const tokens = await prepareForTest();
     requesterToken = tokens.tripOwnerTokenExport;
   });
 
   it(('it successfully returns related search records with a single search string'), async () => {
-    const res = await request(app)
-      .post(`${prefix}/requests/search`)
-      .set('Authorization', requesterToken)
-      .send({
-        travelDate: '2019-01-01',
-        searchString: 'open',
-        returnDate: '2019-12-31'
-      });
+    searchString = 'open';
+    travelDate = '2019-01-01';
+    returnDate = '2019-12-31';
+    res = await request(app)
+      .get(`${prefix}/search/requests?searchString=${searchString}&travelDate=${travelDate}&returnDate=${returnDate}`)
+      .set('Authorization', requesterToken);
     expect(res.status).eql(200);
     expect(res.body.message).eql('successfully retrieved search results');
   });
 
   it(('it successfully returns related search records with multiple search strings'), async () => {
-    const res = await request(app)
-      .post(`${prefix}/requests/search`)
-      .set('Authorization', requesterToken)
-      .send({
-        travelDate: '2019-01-01',
-        searchString: 'open nairobi',
-        returnDate: '2019-12-31'
-      });
+    searchString = 'open nairobi';
+    travelDate = '2019-01-01';
+    returnDate = '2019-12-31';
+    res = await request(app)
+      .get(`${prefix}/search/requests?searchString=${searchString}&travelDate=${travelDate}&returnDate=${returnDate}`)
+      .set('Authorization', requesterToken);
     expect(res.status).eql(200);
   });
 
   it(('it fails to return searched records if search parameters don\'t match existing records'), async () => {
-    const res = await request(app)
-      .post(`${prefix}/requests/search`)
-      .set('Authorization', requesterToken)
-      .send({
-        travelDate: '2020-01-01',
-        searchString: 'open',
-        returnDate: '2020-12-31'
-      });
+    travelDate = '2020-01-01';
+    searchString = 'open';
+    returnDate = '2020-12-31';
+    res = await request(app)
+      .get(`${prefix}/search/requests?searchString=${searchString}&travelDate=${travelDate}&returnDate=${returnDate}`)
+      .set('Authorization', requesterToken);
     expect(res.status).eql(404);
   });
 
   it(('it still returns searched records user doesn\'t supply dates in request'), async () => {
-    const res = await request(app)
-      .post(`${prefix}/requests/search`)
-      .set('Authorization', requesterToken)
-      .send({
-        searchString: 'open',
-      });
+    searchString = 'open';
+    res = await request(app)
+      .get(`${prefix}/search/requests?searchString=${searchString}`)
+      .set('Authorization', requesterToken);
     expect(res.status).eql(200);
   });
 
   it(('it still returns searched records when user doesn\'t supply request status'), async () => {
-    const res = await request(app)
-      .post(`${prefix}/requests/search`)
-      .set('Authorization', requesterToken)
-      .send({
-        searchString: 'Nairobi',
-      });
+    searchString = 'Nairobi';
+    res = await request(app)
+      .get(`${prefix}/search/requests?searchString=${searchString}`)
+      .set('Authorization', requesterToken);
     expect(res.status).eql(200);
+  });
+
+  it(('it returns an error when searchString not passed'), async () => {
+    res = await request(app)
+      .get(`${prefix}/search/requests`)
+      .set('Authorization', requesterToken);
+    expect(res.status).eql(400);
   });
 });

--- a/src/utils/schemas.js
+++ b/src/utils/schemas.js
@@ -250,7 +250,7 @@ export default {
   '/hotels': hotelSchema,
   '/hotels/:hotelId/rooms': roomSchema,
   '/booking': bookingSchema,
-  '/requests/search': searchRequestsSchema,
+  '/search/requests': searchRequestsSchema,
   '/trips/stats': tripsStatsSchema,
   '/hotels/:hotelId/feedback': feedbackSchema,
   '/hotels/:hotelId/rating': rateSchema,

--- a/src/validation/validation.js
+++ b/src/validation/validation.js
@@ -64,4 +64,25 @@ const validateMultiCity = (req, res, next) => {
   }
 };
 
-export { validation, validateMultiCity };
+/**
+ * Validates the signup or signin routes using the defined schemas
+ * @param {object} req
+ * @param {object} res
+ * @param {function} next
+ * @returns {void}
+ */
+const validateSearch = (req, res, next) => {
+  const { path } = req.route;
+  const schema = Schemas[path];
+
+  return Joi.validate(req.query, schema, (error, data) => {
+    if (error) {
+      const err = error.details.map(e => (e.message));
+      return Responses.handleError(400, err, res);
+    }
+    req.body = data;
+    next();
+  });
+};
+
+export { validation, validateMultiCity, validateSearch };


### PR DESCRIPTION
#### What does this PR do?
This PR refactors the search requests functionality to use a GET route instead of a POST route

#### Description of Task to be completed?
Refactor the following files:
- [x] request route
- [x] request controller and service
- [x] refactor tests 

#### How should this be manually tested?
- Clone this repository and navigate to the project folder using Terminal
- rerun migrations on development and test databases using `npm run migrate` and `npm run pretest-travis`
- run tests on Terminal using `npm test`
- run seeder files on development database using `npm run db:seed`
- Test with Postman:
  - Create various trips with different origins and destinations and different travel dates and return dates
  - Using the same token you used to create the trips, attempt to search for specific trips using the endpoint: '/GET /search/requests' using the following query parameters (**'travelDate' and 'returnDate' are optional, you can pass a location of your choice to the searchString as well**):
```
    travelDate: 2019-08-01
    searchString: open
    returnDate: 2019-12-31

```
- Vary the dates and searchString to match your desired trips to get filtered results

#### Any background context you want to provide?
This PR refactors the code introduced by the story [#169257417](https://www.pivotaltracker.com/story/show/169257417) to comply with standard RESTFUL design patterns

#### What are the relevant pivotal tracker stories?
[#170276566](https://www.pivotaltracker.com/story/show/170276566)

#### Screenshots (if appropriate)
<img width="1437" alt="Screen Shot 2019-12-13 at 18 35 13" src="https://user-images.githubusercontent.com/17108099/70816047-5a658c00-1dd7-11ea-902b-22689ae51193.png">

#### Questions:
N/A