### PR TITLE
 #170575370 Bug Fix social authentication redirect response

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,26 +1,26 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable camelcase */
 /* eslint-disable class-methods-use-this */
+/* eslint-disable no-unused-vars */
 import db from '../models';
 import JWTToken from '../utils/jwt';
-import { randomPw } from '../utils/helpers';
-import hash from '../utils/hash';
-import Responses from '../utils/response';
 
 export const getTokenAfterSignIn = async (res, user) => {
-  try {
-    const userDetails = user.dataValues;
-    const token = await JWTToken.signToken(userDetails);
-    return Responses.handleSuccess(201, 'User logged in successfully', res, { token });
-  } catch (e) {
-    return Responses.handleError(500, e.message, res);
-  }
+  const userDetails = user.dataValues;
+  const token = await JWTToken.signToken(userDetails);
+  const cookieOptions = {
+    httpOnly: true,
+    maxAge: new Date(Date.now() + 86400),
+  };
+  return res.status(200)
+    .cookie('bn_auth_token', token, cookieOptions)
+    .redirect(`${process.env.FRONTEND_URL}/profile`);
 };
 
 /** Auth Class */
 class AuthController {
   /**
-   * facebookSignin
+   * facebookSignIn
    *
    * @param {object} req - request object
    * @param {object} res - response object
@@ -29,7 +29,7 @@ class AuthController {
    * @memberof AuthController
    *
    */
-  async facebookSignin(req, res) {
+  async facebookSignIn(req, res) {
     const { first_name, last_name, email } = req.user._json;
     await db.user.findOrCreate({
       where: { email },
@@ -38,11 +38,8 @@ class AuthController {
         lastName: last_name,
         email,
         isVerified: true,
-        password: hash.generateSync(randomPw(8)),
-      }
-    })
-    // eslint-disable-next-line no-unused-vars
-      .spread((user$, isCreated) => getTokenAfterSignIn(res, user$));
+      },
+    }).spread((user$, isCreated) => getTokenAfterSignIn(res, user$));
   }
 
   /**
@@ -61,12 +58,10 @@ class AuthController {
       defaults: {
         firstName: displayName.split(' ')[0],
         lastName: displayName.split(' ')[1],
-        email: emails[0].value,
-        isVerified: true
-      }
-    })
-    // eslint-disable-next-line no-unused-vars
-      .spread((user, isCreated) => getTokenAfterSignIn(res, user));
+        email: emails.find(email => email.verified) || emails[0].value,
+        isVerified: true,
+      },
+    }).spread((user, isCreated) => getTokenAfterSignIn(res, user));
   }
 }
 

--- a/src/routes/api/auth.js
+++ b/src/routes/api/auth.js
@@ -7,10 +7,10 @@ const authRouter = express.Router();
 
 authRouter.get('/auth/facebook', passport.authenticate('facebook', { scope: ['email'] }));
 
-authRouter.get('/auth/facebook/callback', passport.authenticate('facebook', { session: false }), catchErrors(AuthController.facebookSignin));
+authRouter.get('/auth/facebook/callback', passport.authenticate('facebook', { failureRedirect: `${process.env.FRONTEND_URL}/login` }), catchErrors(AuthController.facebookSignIn));
 
 authRouter.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
 
-authRouter.get('/auth/google/callback', passport.authenticate('google', { session: false }), catchErrors(AuthController.googleSignIn));
+authRouter.get('/auth/google/callback', passport.authenticate('google', { failureRedirect: `${process.env.FRONTEND_URL}/login` }), catchErrors(AuthController.googleSignIn));
 
 export default authRouter;

--- a/src/tests/units/controllers/authController.test.js
+++ b/src/tests/units/controllers/authController.test.js
@@ -5,10 +5,10 @@
 /* eslint-disable import/no-named-as-default */
 /* eslint-disable import/no-named-as-default-member */
 import { expect } from 'chai';
-import AuthController, { getTokenAfterSignIn } from '../../../controllers/auth.controller';
+import AuthController from '../../../controllers/auth.controller';
 import db from '../../../models';
 
-const { googleSignIn, facebookSignin } = AuthController;
+const { googleSignIn, facebookSignIn } = AuthController;
 
 const mocks = require('node-mocks-http');
 
@@ -42,6 +42,8 @@ const OAuthData = {
   }
 };
 
+const { facebook, google } = OAuthData;
+
 describe('Social Authentication', () => {
   beforeEach(async () => {
     await db.user.destroy({
@@ -50,25 +52,21 @@ describe('Social Authentication', () => {
     });
   });
 
-  it('should fail to give the Token when the response is not from OAuth', async () => {
-    const data = await getTokenAfterSignIn(response, OAuthData.facebook.request.user);
-    expect(data.statusCode)
-      .eql(500);
-  });
-
   it('should create a Facebook and save him in the db', async () => {
-    const { email } = OAuthData.facebook.request.user._json;
-    await facebookSignin(OAuthData.facebook.request, OAuthData.facebook.response);
+    // eslint-disable-next-line no-shadow
+    const { request, response } = facebook;
+    const { email } = request.user._json;
+    await facebookSignIn(request, response);
     const user = await db.user.findOne({ where: { email } });
-    expect(email)
-      .eql(user.dataValues.email);
+    expect(email).eql(user.dataValues.email);
   });
 
   it('should create a Google and save in in the db', async () => {
-    const email = OAuthData.google.request.user.emails[0].value;
-    await googleSignIn(OAuthData.google.request, OAuthData.google.response);
+    // eslint-disable-next-line no-shadow
+    const { request, response } = google;
+    const email = request.user.emails[0].value;
+    await googleSignIn(request, response);
     const user = await db.user.findOne({ where: { email } });
-    expect(email)
-      .eql(user.dataValues.email);
+    expect(email).eql(user.dataValues.email);
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Updates the social authentication to redirect to the user profile page (on the front end) with a Token in the cookie upon success, or to redirect him back to the Login page on failure
#### Description of Task to be completed?
 - Updated the response from Social Auth Controllers from a JSON object to redirection to the user profile page with a token string within a cookie
 - Added a failureRedirect property on the Social Auth Routes, to redirect the user back to the login page on failure to authenticate him
 - Fixed the tests for Social Authentication functionality
#### How should this be manually tested?
- git clone the repo
- run `npm install` to install dependencies
- run `npm run migrate` to make migrations
- got to forgot password route and run `{{url}}/api/v1/auth/facebook` or  `{{url}}/api/v1/auth/google` and authenticate with the actual facebook or google credential. The user will be the redirected back to the application
- check the browser cookies to find the "bn_auth_token" string, which is the token for the authenticated user with Social login.
#### Any background context you want to provide?
- Create the `FRONTEND_URL` environment variable and assign it with the frontend URL eg: `http://localhost:8080`
#### What are the relevant pivotal tracker stories?
[ #170575370](https://www.pivotaltracker.com/story/show/170575370)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A
