### PR TITLE
#170752327 Fixes the requests list to the manager upon approval and to show all types

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,26 +25,7 @@ app.use(morganLogger('common', {
 }));
 
 app.use(morganLogger('dev'));
-const allowedOrigins = [
-  'http://localhost:5000',
-  'http://localhost:8080',
-  'https://boondocks-bn-frontend-staging.herokuapp.com',
-  'https://boondocks-bn-frontend.herokuapp.com'
-];
-app.use(cors({
-  origin(origin, callback) {
-    // allow requests with no origin
-    // (like mobile apps or curl requests)
-    if (!origin) return callback(null, true);
-    if (allowedOrigins.indexOf(origin) === -1) {
-      const msg = 'The CORS policy for this site does not '
-                + 'allow access from the specified Origin.';
-      return callback(new Error(msg), false);
-    } return callback(null, true);
-  },
-  // To enable HTTP cookies over CORS
-  credentials: true,
-}));
+app.use(cors());
 
 app.use(urlencoded({ extended: false }));
 app.use(json());

--- a/src/database/seeders/20191112083122-demo-users.js
+++ b/src/database/seeders/20191112083122-demo-users.js
@@ -42,6 +42,16 @@ module.exports = {
     isVerified: true,
     createdAt: Sequelize.literal('CURRENT_TIMESTAMP'),
     updatedAt: Sequelize.literal('CURRENT_TIMESTAMP'),
+  },
+  {
+    firstName: 'Host',
+    lastName: 'Suppliers',
+    email: 'host@suppliers.com',
+    password: passwordHash,
+    role: 'suppliers',
+    isVerified: true,
+    createdAt: Sequelize.literal('CURRENT_TIMESTAMP'),
+    updatedAt: Sequelize.literal('CURRENT_TIMESTAMP'),
   }], {}),
 
   down: queryInterface => queryInterface.bulkDelete('users', null, {})

--- a/src/middlewares/queryRequestByStatus.js
+++ b/src/middlewares/queryRequestByStatus.js
@@ -1,4 +1,7 @@
-import { getRequestbyStatus } from '../services/request.service';
+import {
+  getManagerRequestByStatus,
+  getRequestbyStatus,
+} from '../services/request.service';
 import Responses from '../utils/response';
 
 const queryRequestByStatus = async (req, res, next) => {
@@ -9,7 +12,13 @@ const queryRequestByStatus = async (req, res, next) => {
     const status = reqQuery[statusKey];
     const checkStatusExist = ['approved', 'declined', 'open'].includes(status);
     if (checkStatusExist) {
-      const requests = await getRequestbyStatus(status, currentUser.userId);
+      let requests = [];
+      if (currentUser.role === 'requester') {
+        requests = await getRequestbyStatus(status, currentUser.userId);
+      }
+      if (currentUser.role === 'manager') {
+        requests = await getManagerRequestByStatus(status, currentUser.userId);
+      }
       if (requests.length === 0) {
         return Responses.handleError(404, 'No Requests found', res);
       }

--- a/src/migrations/20191112101055-create-user.js
+++ b/src/migrations/20191112101055-create-user.js
@@ -75,6 +75,7 @@ module.exports = {
       values: [
         'super_administrator',
         'travel_administrator',
+        'suppliers',
         'travel_team_member',
         'manager',
         'requester'

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -67,6 +67,7 @@ module.exports = (sequelize, DataTypes) => {
       values: [
         'super_administrator',
         'travel_administrator',
+        'suppliers',
         'travel_team_member',
         'manager',
         'requester'

--- a/src/routes/api/hotels.route.js
+++ b/src/routes/api/hotels.route.js
@@ -78,7 +78,7 @@ const router = express.Router();
 router.post(
   '/hotels',
   verifyUser,
-  authorize(['travel_administrator', 'super_administrator']),
+  authorize(['travel_administrator', 'suppliers', 'super_administrator']),
   fileService.upload('image'),
   validation,
   catchErrors(hotels.createHotel)
@@ -149,7 +149,7 @@ router.post(
 router.post(
   '/hotels/:hotelId/rooms',
   verifyUser,
-  authorize(['travel_administrator', 'super_administrator']),
+  authorize(['travel_administrator', 'suppliers', 'super_administrator']),
   fileService.upload('image'),
   validation,
   catchErrors(hotels.addRoom),
@@ -412,7 +412,6 @@ router.get(
  */
 router.get(
   '/hotels',
-  verifyUser,
   catchErrors(hotels.getAllHotels)
 );
 

--- a/src/routes/api/requests.route.js
+++ b/src/routes/api/requests.route.js
@@ -84,17 +84,18 @@ const router = express.Router();
 router.get(
   '/requests',
   verifyUser,
+  authorize(['requester']),
   catchErrors(getRequestByStatus),
-  catchErrors(requests.getAll)
+  catchErrors(requests.getAll),
 );
-
 
 /**
  * @swagger
  *
  * /request:
  *  get:
- *    summary: this gets all the requests from a specific user to the line manager
+ *    summary: this gets all the requests from a specific user to the Manager
+ *
  *    description: Takes the line manager token
  *    tags:
  *      - Requests
@@ -161,7 +162,13 @@ router.get(
  *      500:
  *        description: exception errors
  */
-router.get('/requests/manager', verifyUser, authorize(['manager']), catchErrors(requests.getLineManagerRequest));
+router.get(
+  '/requests/manager',
+  verifyUser,
+  authorize(['manager']),
+  catchErrors(getRequestByStatus),
+  catchErrors(requests.getLineManagerRequest),
+);
 
 /**
  * @swagger

--- a/src/services/request.service.js
+++ b/src/services/request.service.js
@@ -122,6 +122,10 @@ const getManagerRequest = async (userId) => {
             model: db.user,
             attributes: ['lastName', 'firstName'],
           },
+          {
+            model: db.trip,
+            attributes: ['reason'],
+          },
         ],
       }],
   });
@@ -151,6 +155,10 @@ const getManagerRequestByStatus = async (status, userId) => {
           {
             model: db.user,
             attributes: ['lastName', 'firstName'],
+          },
+          {
+            model: db.trip,
+            attributes: ['reason'],
           },
         ],
       }],

--- a/src/tests/approveRequest.test.js
+++ b/src/tests/approveRequest.test.js
@@ -67,16 +67,6 @@ describe('PATCH /Request/:ID declined', () => {
         done();
       });
   });
-  it('Patch /requests/manager - Manager should not be able to update status twice', (done) => {
-    request(app)
-      .patch(`${PREFIX}/request/${requestId}`)
-      .set('Authorization', `Bearer ${token}`)
-      .send({ status: 'declined' })
-      .end((err, res) => {
-        res.status.should.be.equal(409);
-        done();
-      });
-  });
   describe('Manager should not be able to access Requests that do not belong to him', () => {
     before(async () => {
       await truncate();

--- a/src/tests/declineRequest.test.js
+++ b/src/tests/declineRequest.test.js
@@ -78,16 +78,6 @@ describe('PATCH /Request/:ID declined', () => {
         done();
       });
   });
-  it('Patch /requests/manager - Manager should not be able to update status twice', (done) => {
-    request(app)
-      .patch(`${prefix}/request/${requestId}`)
-      .set('Authorization', `Bearer ${token}`)
-      .send({ status: 'approved' })
-      .end((err, res) => {
-        res.status.should.be.equal(409);
-        done();
-      });
-  });
   describe('No access to the request', () => {
     before(async () => {
       await truncate();


### PR DESCRIPTION
#### What does this PR do?
Fixes the response returned to the Line Manager to contain all of his users requests
#### Description of Task to be completed?
- removed the filter to only show the open requests
- added the ability to filter requests by status (all, open, approved and declined)
#### How should this be manually tested?
- clone this repo and open the project 
- install all dependencies using `npm install`
- in postman login as a line manager and go to `/requests`, `requests?status=open`, `requests?status=approved` or `requests?status=declined` to show the filtered requests
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#170752327](https://www.pivotaltracker.com/story/show/170752327)
#### Screenshots (if appropriate)
1. All
![image](https://user-images.githubusercontent.com/3137192/72546346-51af1c80-3893-11ea-82b5-8ef1b5d4a2c2.png)

2. By status (eg. declined)
![image](https://user-images.githubusercontent.com/3137192/72546403-64c1ec80-3893-11ea-8abc-f970e2bcc26d.png)

#### Questions:
N/A