### PR TITLE
#170846344 fix the trip request validation to allow null

### DIFF
--- a/src/controllers/trips.controller.js
+++ b/src/controllers/trips.controller.js
@@ -95,6 +95,7 @@ class Trip {
         leavingFrom,
         goingTo,
         travelDate,
+        returnDate,
         reason,
         rooms
       } = travel;
@@ -105,6 +106,7 @@ class Trip {
         leavingFrom,
         goingTo,
         travelDate,
+        returnDate,
         reason,
         rooms,
         requestId,

--- a/src/services/request.service.js
+++ b/src/services/request.service.js
@@ -76,7 +76,12 @@ const getOneRequest = async (requestId) => {
       ]
     },
     {
-      model: db.comment
+      model: db.comment,
+      include: [{
+        model: db.user,
+        as: 'author',
+        attributes: ['firstName', 'lastName']
+      }]
     },
     {
       model: db.user,

--- a/src/utils/schemas.js
+++ b/src/utils/schemas.js
@@ -112,7 +112,7 @@ const hotelSchema = Joi.object().keys({
 });
 
 const updateTripSchema = Joi.object().keys({
-  hotelId: Joi.number(),
+  hotelId: Joi.number().allow(null, ''),
   type: Joi.string().strict().trim().valid(
     'one way',
     'return'
@@ -121,7 +121,7 @@ const updateTripSchema = Joi.object().keys({
   leavingFrom: Joi.number().strict(),
   goingTo: Joi.number().strict(),
   travelDate: Joi.date(),
-  returnDate: Joi.date().when('type', { is: 'return', then: Joi.required() }),
+  returnDate: Joi.date().when('type', { is: 'return', then: Joi.required() }).allow(null, ''),
   rooms: Joi.array().items(Joi.number().error(() => 'rooms must be an integer value')),
   reason: Joi.string().strict()
 }).options({


### PR DESCRIPTION
#### What does this PR do?
fixes the bug allows null to the fields that are option like hotel and rooms
#### Description of Task to be completed?
- [x] add allow null to validation schema
#### How should this be manually tested?
- git clone the repo
- run `npm install` to install dependencies
- run `npm test` to run the tests
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[#170846344]()
#### Screenshots (if appropriate)
#### Questions:
