### PR TITLE
#171097348 Fix for multi-city trip requests

### DIFF
--- a/src/tests/mock-data/trips-data.js
+++ b/src/tests/mock-data/trips-data.js
@@ -65,10 +65,9 @@ export default {
     leavingFrom: 1,
     goingTo: 2,
     travelDate: '2019-11-18',
-    returnDate: '2019-11-20',
     reason: 'visit our agents',
     hotelId: 1,
-    type: 'return',
+    type: 'one way',
     rooms: [2]
   },
   {
@@ -92,10 +91,9 @@ export default {
     leavingFrom: 1,
     goingTo: 2,
     travelDate: '2019-11-18',
-    returnDate: '2019-11-19',
     reason: 'visit our agents',
     hotelId: 1,
-    type: 'return',
+    type: 'one way',
     rooms: [5]
   }],
   requests: [{

--- a/src/validation/validation.js
+++ b/src/validation/validation.js
@@ -45,7 +45,7 @@ const validateMultiCity = (req, res, next) => {
   if (methodsSupported.includes(method)) {
     const trips = req.body;
     const errors = trips.map((item) => {
-      const path = item.type === 'return' ? '/trips/return' : '/trips/oneway';
+      const path = '/trips/oneway';
       const schema = Schemas[path];
       let err;
       Joi.validate(item, schema, (error) => {


### PR DESCRIPTION
#### What does this PR do?
This PR makes some fixes on the back-end so that multi-city trip requests can be successfully posted on the front-end

#### Description of Task to be completed?
- [x] change validation for multi-city to 'one way' only
- [x] refactor check room availability middleware for multi-city to check trips with and without bookings

#### How should this be manually tested?
- clone this repo and navigate to the project folder using Terminal
- install dependencies using `npm install`
- run unit and integration tests using `npm run pretest-travis && npm test`
- start the server using `npm run watch`
- using Postman
  - create multi-city trips both with and without booking (only 'one-way' trips will work and unavailable rooms will be flagged as booked)

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#171097348](https://www.pivotaltracker.com/story/show/171097348)

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2020-02-05 at 21 21 49" src="https://user-images.githubusercontent.com/17108099/73875221-978d4e00-485d-11ea-8dba-e835e09f253e.png">

#### Questions:
N/A