### PR TITLE
#171326822 Add profile picture to user profile

### DIFF
--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -6,6 +6,7 @@ import JWTHelper from '../utils/jwt';
 import db from '../models';
 import UserServices from '../services/User.service';
 import Mailer from '../services/Mailer.services';
+import filesService from '../services/files.service';
 
 /**
  * Class for users related operations
@@ -179,7 +180,19 @@ class UserController {
     const userData = { ...req.body };
     const { user } = res.locals;
 
-    const data = await UserServices.updateUserInfoByEmail({ ...userData }, user.email);
+    let profilePicture = '';
+    if (req.file !== undefined) {
+      const {
+        filename,
+        path
+      } = req.file;
+
+      profilePicture = await filesService.s3Upload(path, filename, 'profile_pics');
+    }
+
+    const data = await UserServices.updateUserInfoByEmail({
+      ...userData, profilePicture
+    }, user.email);
 
     if (data === 'own_manage') {
       return Responses.handleError(409, 'You cannot manage your self', res);

--- a/src/migrations/20200217191855-add-profile-picture-field-to-users.js
+++ b/src/migrations/20200217191855-add-profile-picture-field-to-users.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => Promise.all([
+    queryInterface.addColumn('users', 'profilePicture', {
+      type: Sequelize.STRING,
+    })
+  ]),
+
+  down: (queryInterface) => Promise.all([
+    queryInterface.removeColumn('users', 'profilePicture')
+  ])
+};

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -86,7 +86,11 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
       allowNull: false
-    }
+    },
+    profilePicture: {
+      allowNull: true,
+      type: DataTypes.STRING
+    },
   }, {});
   User.associate = (models) => {
     User.hasMany(models.booking, {

--- a/src/routes/api/hotels.route.js
+++ b/src/routes/api/hotels.route.js
@@ -79,7 +79,10 @@ router.post(
   '/hotels',
   verifyUser,
   authorize(['travel_administrator', 'suppliers', 'super_administrator']),
-  fileService.upload('image'),
+  fileService.upload('image',
+    ['image/png', 'image/jpg', 'image/jpeg'],
+    'Only .png, .jpg and .jpeg format allowed!'
+  ),
   validation,
   catchErrors(hotels.createHotel)
 );
@@ -150,7 +153,10 @@ router.post(
   '/hotels/:hotelId/rooms',
   verifyUser,
   authorize(['travel_administrator', 'suppliers', 'super_administrator']),
-  fileService.upload('image'),
+  fileService.upload('image',
+    ['image/png', 'image/jpg', 'image/jpeg'],
+    'Only .png, .jpg and .jpeg format allowed!'
+  ),
   validation,
   catchErrors(hotels.addRoom),
 );

--- a/src/routes/api/users.route.js
+++ b/src/routes/api/users.route.js
@@ -4,6 +4,7 @@ import checkForEmail from '../../validation/user.validation';
 import { validation } from '../../validation/validation';
 import catchErrors from '../../utils/helper';
 import { decodeQueryToken, verifyUser } from '../../middlewares/checkToken';
+import fileService from '../../services/files.service';
 
 const {
   updateUserInfo,
@@ -346,6 +347,10 @@ router.patch(
 router.patch(
   '/user/update-profile',
   verifyUser,
+  fileService.upload('profilePicture',
+    ['image/png', 'image/jpg', 'image/jpeg'],
+    'Only .png, .jpg and .jpeg format allowed!'
+  ),
   validation,
   catchErrors(updateUserInfo)
 );

--- a/src/services/User.service.js
+++ b/src/services/User.service.js
@@ -42,7 +42,8 @@ class UserServices {
           'lastLogin',
           'role',
           'phoneNumber',
-          'remember'
+          'remember',
+          'profilePicture'
         ],
         include: ['LineManager'],
       },
@@ -60,7 +61,7 @@ class UserServices {
   async updateUserInfoByEmail(attributes, email$) {
     const {
       firstName, lastName, email, birthDate, preferredLanguage, preferredCurrency, residenceAddress,
-      gender, department, lineManagerId, phoneNumber, remember,
+      gender, department, lineManagerId, phoneNumber, remember, profilePicture
     } = attributes;
 
 
@@ -82,21 +83,27 @@ class UserServices {
     } else if (!isLineManagerValid) {
       result = 'invalid_manager';
     } else {
+      const updateObj = {
+        firstName,
+        lastName,
+        birthDate,
+        preferredLanguage,
+        preferredCurrency,
+        gender,
+        email,
+        residenceAddress,
+        lineManagerId,
+        department,
+        phoneNumber,
+        remember
+      };
+
+      if (profilePicture !== '') {
+        updateObj.profilePicture = profilePicture;
+      }
+
       const userDetails = await db.user.update(
-        {
-          firstName,
-          lastName,
-          birthDate,
-          preferredLanguage,
-          preferredCurrency,
-          gender,
-          email,
-          residenceAddress,
-          lineManagerId,
-          department,
-          phoneNumber,
-          remember,
-        },
+        updateObj,
         {
           where: { email: email$ },
           returning: true,

--- a/src/tests/mock-data/images/not_an_image.txt
+++ b/src/tests/mock-data/images/not_an_image.txt
@@ -1,0 +1,1 @@
+Not an image file

--- a/src/tests/userProfile.test.js
+++ b/src/tests/userProfile.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable object-curly-newline */
 import chaiHttp from 'chai-http';
 import { expect, request, should, use } from 'chai';
+import { resolve } from 'path';
 import app from '../app';
 import tokenizer from '../utils/jwt';
 import db from '../models';
@@ -103,11 +104,46 @@ describe('User profile', () => {
   });
 
   describe('/PATCH api/v1/user/update-profile', () => {
-    it('it should return a 201 response upon authorization', (done) => {
+    it('it should update profile that includes a profile picture upload', (done) => {
       request(app)
         .patch(`${prefix}/user/update-profile`)
         .set('Authorization', token)
-        .send(userDetails)
+        .field('firstName', 'Johnny')
+        .field('lastName', 'Doey')
+        .field('password', 'newPassword8')
+        .field('email', 'john@barefoot.com')
+        .field('phoneNumber', '000-000-0012')
+        .field('lineManagerId', managerId)
+        .field('gender', 'male')
+        .field('preferredLanguage', 'english')
+        .field('preferredCurrency', '$')
+        .field('department', 'IT')
+        .field('birthDate', '1950-01-01T00:00:00.000Z')
+        .field('residenceAddress', 'Kigali, Rwanda')
+        .attach('profilePicture', resolve(__dirname, 'mock-data/images/search.png'))
+        .end((_err, res) => {
+          expect(res.status)
+            .eql(201);
+          done();
+        });
+    });
+
+    it('it should update profile that doesn\'t includes a profile picture upload', (done) => {
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .set('Authorization', token)
+        .field('firstName', 'JohnnyEdited')
+        .field('lastName', 'Doey')
+        .field('password', 'newPassword8')
+        .field('email', 'john@barefoot.com')
+        .field('phoneNumber', '000-000-0012')
+        .field('lineManagerId', managerId)
+        .field('gender', 'male')
+        .field('preferredLanguage', 'english')
+        .field('preferredCurrency', '$')
+        .field('department', 'IT')
+        .field('birthDate', '1950-01-01T00:00:00.000Z')
+        .field('residenceAddress', 'Kigali, Rwanda')
         .end((_err, res) => {
           expect(res.status)
             .eql(201);
@@ -172,6 +208,30 @@ describe('User profile', () => {
         .end((err, res) => {
           expect(res.status)
             .eql(401);
+          done();
+        });
+    });
+
+    it('it should fail to update a profile if uploaded file is not an image', (done) => {
+      request(app)
+        .patch(`${prefix}/user/update-profile`)
+        .set('Authorization', token)
+        .field('firstName', 'Johnny')
+        .field('lastName', 'Doey')
+        .field('password', 'newPassword8')
+        .field('email', 'john@barefoot.com')
+        .field('phoneNumber', '000-000-0012')
+        .field('lineManagerId', managerId)
+        .field('gender', 'male')
+        .field('preferredLanguage', 'english')
+        .field('preferredCurrency', '$')
+        .field('department', 'IT')
+        .field('birthDate', '1950-01-01T00:00:00.000Z')
+        .field('residenceAddress', 'Kigali, Rwanda')
+        .attach('profilePicture', resolve(__dirname, 'mock-data/images/not_an_image.txt'))
+        .end((_err, res) => {
+          expect(res.status)
+            .eql(500);
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
Allows a user to add and update a profile picture to their profile

#### Description of Task to be completed?
- [x] add a profile picture field to the users' table
- [x] update models, controllers, and services
- [x] refactor tests

#### How should this be manually tested?
- clone this repo and install dependencies
- run tests using `npm run pretest-travis  && npm test`
- test with Postman
  - start the server with `npm run watch`
  - make a request to the endpoint '{{url}}/api/v1/user/update-profile' and include a profile picture using a form request as follows:
<img width="1112" alt="Screen Shot 2020-02-20 at 12 38 18" src="https://user-images.githubusercontent.com/17108099/74926015-e8fd1780-53dd-11ea-81de-ae294f54ac5c.png">

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#171326822](https://www.pivotaltracker.com/story/show/171326822)

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2020-02-20 at 12 42 46" src="https://user-images.githubusercontent.com/17108099/74926484-a12ac000-53de-11ea-8551-3fb2ff911ee1.png">

#### Questions:
N/A