### PR TITLE
#171304386 allow users to upload travel documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ trash/
 .DS_Store
 src/migrations/.DS_Store
 public/images
+public/temp
+public/documents
+public/profile_pictures

--- a/src/controllers/hotels.controller.js
+++ b/src/controllers/hotels.controller.js
@@ -40,10 +40,11 @@ class Hotel {
     if (req.file !== undefined) {
       const {
         filename,
-        path
+        path,
+        mimetype,
       } = req.file;
 
-      image = await filesService.s3Upload(path, filename, 'hotels');
+      image = await filesService.s3Upload({ path, filename, mimetype }, 'hotels');
     }
 
     const hotel = await hotelService.create({
@@ -88,10 +89,11 @@ class Hotel {
     if (req.file !== undefined) {
       const {
         filename,
-        path
+        path,
+        mimetype,
       } = req.file;
 
-      image = await filesService.s3Upload(path, filename, 'rooms');
+      image = await filesService.s3Upload({ path, filename, mimetype }, 'rooms');
     }
     const status = 'available';
 

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,13 +1,17 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable no-bitwise */
 /* eslint-disable no-else-return */
+import fs from 'fs';
+import request from 'request';
+import { resolve as resolv } from 'path';
 import Responses from '../utils/response';
 import hash from '../utils/hash';
 import JWTHelper from '../utils/jwt';
 import db from '../models';
-import UserServices from '../services/User.service';
 import Mailer from '../services/Mailer.services';
 import filesService from '../services/files.service';
-
+import UserService from '../services/User.service';
+import ErrorHandler from '../utils/error';
 /**
  * Class for users related operations
  */
@@ -53,7 +57,7 @@ class UserController {
    * excluing the password
    */
   async findUser(req, res) {
-    const user = await UserServices.findUserByEmail(req.body.email);
+    const user = await UserService.findUserByEmail(req.body.email);
     if (!user) {
       return Responses.handleError(404, 'invalid credentials', res);
     }
@@ -124,7 +128,7 @@ class UserController {
    */
   async forgotPassword(req, res) {
     const { host } = req.query;
-    const user = await UserServices.findUserByEmail(req.body.email);
+    const user = await UserService.findUserByEmail(req.body.email);
     if (!user) {
       return Responses.handleError(404, 'User with such email does not exist', res);
     }
@@ -184,13 +188,14 @@ class UserController {
     if (req.file !== undefined) {
       const {
         filename,
-        path
+        path,
+        mimetype,
       } = req.file;
 
-      profilePicture = await filesService.s3Upload(path, filename, 'profile_pics');
+      profilePicture = await filesService.s3Upload({ path, filename, mimetype }, 'profile_pics');
     }
 
-    const data = await UserServices.updateUserInfoByEmail({
+    const data = await UserService.updateUserInfoByEmail({
       ...userData, profilePicture
     }, user.email);
 
@@ -217,7 +222,7 @@ class UserController {
     userId = Number(userId);
 
     if (typeof userId === 'number' && userId > 0 && userId >>> 0 === userId) {
-      const userData = await UserServices.getUserById(userId);
+      const userData = await UserService.getUserById(userId);
 
       if (userData) {
         const user = userData.dataValues;
@@ -275,6 +280,128 @@ class UserController {
 
     const allUsers = await db.user.findAll(options);
     return Responses.handleSuccess(200, 'successfully retrieved all users', res, allUsers);
+  }
+
+  /**
+   * Upload travel documents
+   * @param {object} req
+   * @param {object} res
+   * @returns {object} response
+   */
+  async uploadDocument(req, res) {
+    const {
+      name,
+    } = req.body;
+
+    let url = '';
+    if (req.file === undefined) {
+      return Responses.handleError(400, 'Document not found, upload the document', res);
+    }
+    const {
+      filename,
+      path,
+      mimetype
+    } = req.file;
+
+    url = await filesService.s3Upload({ path, filename, mimetype }, 'documents');
+
+
+    const { userId } = res.locals.user;
+
+    const document = await UserService.addDocument({ name, url, userId });
+    Responses.handleSuccess(201, 'Document uploaded successfully', res, { name, url, userId });
+  }
+
+  /**
+   * Delete travel document
+   * @param {object} req
+   * @param {object} res
+   * @returns {object} response
+   */
+  async deleteDocument(req, res) {
+    const { id } = req.params;
+    const { userId } = res.locals.user;
+
+    const document = await UserService.getDocument(id);
+
+    const isOwner = document.userId === userId;
+
+    if (isOwner) {
+      await UserService.deleteDocument(id);
+      return Responses.handleSuccess(200, 'Document Deleted successfully', res);
+    }
+    return Responses.handleError(409, 'Document does not belong to you', res);
+  }
+
+
+  /**
+   * Retrieve travel document
+   * @param {object} req
+   * @param {object} res
+   * @returns {object} response
+   */
+  async getDocuments(req, res) {
+    const { userId, role } = res.locals.user;
+    let requesterId = null;
+    if (role === 'requester') {
+      requesterId = userId;
+    }
+    const documents = await UserService.retrieveDocuments({ requesterId });
+    Responses.handleSuccess(200, 'Documents retrieved successfully', res, documents);
+  }
+
+  /**
+   * verify a travel document
+   * @param {object} req
+   * @param {object} res
+   * @returns {object} response
+   */
+  async verifyDocument(req, res) {
+    const { id } = req.params;
+    const { userId } = res.locals.user;
+    await UserService.verifyDocument(id, userId);
+    return Responses.handleSuccess(200, 'Document verified successfully', res);
+  }
+
+  /**
+   * Preview document
+   * @param {Object} req
+   * @param {Object} res
+   * @returns {File} document
+   */
+  async downloadDocument(req, res) {
+    const { id } = req.params;
+    const document = await UserService.getDocument(id);
+
+    const dir = 'public/temp';
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+    const documentName = `${document.name}`;
+    const documentOwner = `${document.documentOwner.firstName}-${document.documentOwner.lastName}`;
+    const fileExtension = `${document.url.split('.').pop()}`;
+
+    const filename = `${documentOwner}-${documentName}-${(new Date()).getTime()}.${fileExtension}`;
+    const file = fs.createWriteStream(`public/temp/${filename}`);
+
+    await new Promise((resolve, reject) => {
+      const stream = request({
+        uri: document.url,
+        gzip: true
+      })
+        .pipe(file)
+        .on('finish', () => {
+          resolve();
+        })
+        .on('error', (error) => {
+          reject(error);
+        });
+    }).catch(error => {
+      throw new ErrorHandler(error);
+    });
+
+    res.download(resolv(`public/temp/${filename}`));
   }
 }
 

--- a/src/migrations/20200217114033-create-document.js
+++ b/src/migrations/20200217114033-create-document.js
@@ -1,0 +1,41 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('documents', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    name: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    url: {
+      allowNull: false,
+      type: Sequelize.STRING
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+    },
+    travelAdminId: {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    },
+    verified: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface) => queryInterface.dropTable('documents'),
+};

--- a/src/models/Document.js
+++ b/src/models/Document.js
@@ -1,0 +1,18 @@
+module.exports = (sequelize, DataTypes) => {
+  const Document = sequelize.define('document', {
+    name: DataTypes.STRING,
+    url: DataTypes.STRING,
+    userId: DataTypes.INTEGER,
+    travelAdminId: DataTypes.INTEGER,
+    verified: DataTypes.BOOLEAN
+  }, {});
+  Document.associate = (models) => {
+    Document.belongsTo(models.user, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE',
+      as: 'documentOwner',
+    });
+    Document.belongsTo(models.user, { foreignKey: 'travelAdminId', as: 'admin' });
+  };
+  return Document;
+};

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -133,6 +133,15 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'hotelId',
       onDelete: 'CASCADE'
     });
+    User.hasMany(models.document, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE',
+      as: 'documentowner',
+    });
+    User.hasMany(models.document, {
+      foreignKey: 'travelAdminId',
+      as: 'admin'
+    });
   };
   return User;
 };

--- a/src/routes/api/hotels.route.js
+++ b/src/routes/api/hotels.route.js
@@ -79,10 +79,8 @@ router.post(
   '/hotels',
   verifyUser,
   authorize(['travel_administrator', 'suppliers', 'super_administrator']),
-  fileService.upload('image',
-    ['image/png', 'image/jpg', 'image/jpeg'],
-    'Only .png, .jpg and .jpeg format allowed!'
-  ),
+  fileService.upload('image', 'images', 5, ['image/png', 'image/jpg', 'image/jpeg'],
+    'Only .png, .jpg and .jpeg formats allowed!'),
   validation,
   catchErrors(hotels.createHotel)
 );
@@ -153,10 +151,8 @@ router.post(
   '/hotels/:hotelId/rooms',
   verifyUser,
   authorize(['travel_administrator', 'suppliers', 'super_administrator']),
-  fileService.upload('image',
-    ['image/png', 'image/jpg', 'image/jpeg'],
-    'Only .png, .jpg and .jpeg format allowed!'
-  ),
+  fileService.upload('image', 'images', 5, ['image/png', 'image/jpg', 'image/jpeg'],
+    'Only .png, .jpg and .jpeg formats allowed!'),
   validation,
   catchErrors(hotels.addRoom),
 );

--- a/src/routes/api/users.route.js
+++ b/src/routes/api/users.route.js
@@ -4,11 +4,17 @@ import checkForEmail from '../../validation/user.validation';
 import { validation } from '../../validation/validation';
 import catchErrors from '../../utils/helper';
 import { decodeQueryToken, verifyUser } from '../../middlewares/checkToken';
-import fileService from '../../services/files.service';
+import authorize from '../../middlewares/roleAuthorization';
+import filesService from '../../services/files.service';
 
 const {
   updateUserInfo,
   getUserProfile,
+  uploadDocument,
+  deleteDocument,
+  getDocuments,
+  verifyDocument,
+  downloadDocument,
 } = users;
 
 const router = express.Router();
@@ -347,10 +353,8 @@ router.patch(
 router.patch(
   '/user/update-profile',
   verifyUser,
-  fileService.upload('profilePicture',
-    ['image/png', 'image/jpg', 'image/jpeg'],
-    'Only .png, .jpg and .jpeg format allowed!'
-  ),
+  filesService.upload('profilePicture', 'profile_pictures', 5, ['image/png', 'image/jpg', 'image/jpeg'],
+    'Only .png, .jpg and .jpeg formats allowed!'),
   validation,
   catchErrors(updateUserInfo)
 );
@@ -386,6 +390,44 @@ router.get(
   '/user/:userId',
   verifyUser,
   catchErrors(getUserProfile)
+);
+
+
+router.post(
+  '/users/documents',
+  verifyUser,
+  authorize(['requester']),
+  filesService.upload('document', 'documents', 10,
+    ['image/png', 'image/jpg', 'image/jpeg', 'application/pdf'],
+    'Only .png, .jpg, .jpeg and .pdf formats allowed!'),
+  validation,
+  catchErrors(uploadDocument),
+);
+
+router.delete(
+  '/users/documents/:id',
+  verifyUser,
+  authorize(['requester']),
+  catchErrors(deleteDocument),
+);
+
+router.get(
+  '/users/documents',
+  verifyUser,
+  authorize(['travel_administrator', 'requester']),
+  catchErrors(getDocuments),
+);
+
+router.patch(
+  '/documents/:id/verify',
+  verifyUser,
+  authorize(['travel_administrator']),
+  catchErrors(verifyDocument),
+);
+
+router.get(
+  '/documents/:id/download',
+  catchErrors(downloadDocument),
 );
 
 export default router;

--- a/src/services/User.service.js
+++ b/src/services/User.service.js
@@ -138,6 +138,84 @@ class UserServices {
     const [rowsUpdate, [updatedUser]] = updateUser;
     return updatedUser;
   }
+
+  /**
+   * Save a document details in the database
+   *
+   * @param {Object} param
+   * @param {String} param.name document name
+   * @param {String} param.url document url,
+   * @param {String} param.userId document owner
+   * @returns {Object} document detauils
+   */
+  async addDocument({ name, url, userId }) {
+    return db.document.create({ userId, name, url });
+  }
+
+  /**
+   * Delete a document
+   * @param {Number} id
+   * @returns {Object} Deleted document
+   */
+  async deleteDocument(id) {
+    return db.document.destroy({
+      where: { id }
+    });
+  }
+
+  /**
+   * Retrieve documents
+   * @param {Number} userId
+   * @returns {Object} documents
+   */
+  async retrieveDocuments({ requesterId }) {
+    return db.document.findAll({
+      ...requesterId && { where: { userId: requesterId } },
+      order: [
+        ['id', 'DESC'],
+      ],
+      include: [
+        {
+          model: db.user,
+          as: 'admin',
+          attributes: ['id', 'firstName', 'lastName'],
+        },
+        {
+          model: db.user,
+          as: 'documentOwner',
+          attributes: ['id', 'firstName', 'lastName'],
+        }
+      ]
+    });
+  }
+
+  /**
+   * Retrieve one document
+   * @param {Integer} id
+   * @returns {Object} document
+   */
+  async getDocument(id) {
+    return db.document.findOne({
+      where: { id },
+      include: [{
+        model: db.user,
+        as: 'documentOwner',
+        attributes: ['id', 'firstName', 'lastName'],
+      }],
+    });
+  }
+
+  /**
+   * Verifies document
+   * @param {Integer} id
+   * @param {Integer} userId
+   * @returns {Object} document
+   */
+  async verifyDocument(id, userId) {
+    return db.document.update({ verified: true, travelAdminId: userId }, {
+      where: { id }
+    });
+  }
 }
 
 export default new UserServices();

--- a/src/services/files.service.js
+++ b/src/services/files.service.js
@@ -11,19 +11,21 @@ import ErrorHandler from '../utils/error';
 class fileService {
   /**
   * @param {String} field
-  * @param {Array} accept
-  * @param {String} uploadErrorMessage
+  * @param {String} folderName
+  * @param {String} sizeLimit
+  * @param {Array} accept accepted file formats
+  * @param {String} uploadErrorMessage Error message
   * @returns {object} file
   */
-  upload(field, accept, uploadErrorMessage) {
-    const dir = 'public/images';
+  upload(field, folderName, sizeLimit, accept, uploadErrorMessage) {
+    const dir = `public/${folderName}`;
 
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir);
     }
     const storage = multer.diskStorage({
       destination: (req, file, cb) => {
-        cb(null, 'public/images');
+        cb(null, `public/${folderName}`);
       },
       filename: (req, file, cb) => {
         cb(null, `${Date.now()}-${file.originalname}`);
@@ -39,22 +41,23 @@ class fileService {
         return cb(new Error(uploadErrorMessage));
       }
     };
-
     return multer({
-      limits: { fieldSize: 5 * 1024 * 1024 },
+      limits: { fieldSize: sizeLimit * 1024 * 1024 },
       storage,
-      fileFilter
+      fileFilter,
     }).single(field);
   }
 
   /**
    * Upload a file to AWS S3 Storage
-   * @param {String} path path to file
-   * @param {String} filename file name
+   * @param {String} file path to file
+   * @param {String} file.path path to file
+   * @param {String} file.filename file name
+   * @param {String} file.mimetype file content type
    * @param {String} s3Folder S3 destination folder
    * @returns {String} S3 url
    */
-  async s3Upload(path, filename, s3Folder) {
+  async s3Upload({ path, filename, mimetype }, s3Folder) {
     aws.config.setPromisesDependency();
     const keysExist = s3Config.S3_ACCESS_KEY_ID
                           && s3Config.S3_SECRET_ACCESS_KEY
@@ -76,7 +79,8 @@ class fileService {
       ACL: 'public-read',
       Bucket: s3Config.S3_BUCKET_NAME,
       Body: fs.createReadStream(path),
-      Key: `${s3Folder}/${filename}`
+      Key: `${s3Folder}/${filename}`,
+      ContentType: mimetype,
     };
 
     let data = null;

--- a/src/tests/documents.test.js
+++ b/src/tests/documents.test.js
@@ -1,0 +1,198 @@
+import { use, request, expect, should } from 'chai';
+import chaiHttp from 'chai-http';
+import { resolve } from 'path';
+import app from '../app';
+import tokenizer from '../utils/jwt';
+import db from '../models';
+import truncate from './scripts/truncate';
+
+should();
+use(chaiHttp);
+let user, user2, user3, token, token2, token3;
+describe('Travel documents', () => {
+  const prefix = '/api/v1';
+
+  before(async () => {
+    await truncate();
+
+    user = await db.user.create({
+      id: 1,
+      firstName: 'John',
+      lastName: 'Doe',
+      password: '12345678',
+      email: 'john@barefoot.com',
+      role: 'requester',
+    });
+    user2 = await db.user.create({
+      id: 2,
+      firstName: 'John',
+      lastName: 'Doe',
+      password: '12345678',
+      email: 'johndoe@barefoot.com',
+      role: 'requester',
+    });
+
+    user3 = await db.user.create({
+      id: 3,
+      firstName: 'John',
+      lastName: 'Doe',
+      password: '12345678',
+      email: 'johndoee@barefoot.com',
+      role: 'travel_administrator',
+    });
+
+    await db.document.create({
+      id: 100,
+      name: 'VISA',
+      url: 'https://boondocks-bn-images.s3.us-east-2.amazonaws.com/test/test-doc.jpeg',
+      userId: 1,
+      travelAdminId: 1,
+      verified: true,
+    });
+
+    await db.document.create({
+      id: 102,
+      name: 'VISA',
+      url: 'google.png',
+      userId: 1,
+      travelAdminId: 1,
+      verified: true,
+    });
+
+    token = await tokenizer.signToken({
+      id: user.id,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: user.email,
+      isVerified: true,
+    });
+    token2 = await tokenizer.signToken({
+      id: user2.id,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: user2.email,
+      isVerified: true,
+    });
+
+    token3 = await tokenizer.signToken({
+      id: user3.id,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: user3.email,
+      isVerified: true,
+    });
+  });
+
+  describe('Travel Documents', () => {
+    it('POST /users/documents should allow the user to upload documents', (done) => {
+      request(app)
+        .post(`${prefix}/users/documents`)
+        .set('Authorization', `Bearer ${token}`)
+        .field('name', 'VISA')
+        .attach('document', resolve(__dirname, 'mock-data/images/search.png'))
+        .end((err, res) => {
+          res.status.should.be.eql(201);
+          const { data } = res.body;
+          data.should.be.an('object');
+          done();
+        });
+    });
+
+    it('POST /users/documents should not save document if no file uploaded', (done) => {
+      request(app)
+        .post(`${prefix}/users/documents`)
+        .set('Authorization', `Bearer ${token}`)
+        .field('name', 'VISA')
+        .end((err, res) => {
+          expect(res.status).to.eql(400);
+          done();
+        });
+    });
+    it('GET /users/documents should allow the user to retrieve documents', (done) => {
+      request(app)
+        .get(`${prefix}/users/documents`)
+        .set('Authorization', `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(200);
+          done(err);
+        });
+    });
+
+    it('GET /users/documents should allow travel admin to retrieve documents', (done) => {
+      request(app)
+        .get(`${prefix}/users/documents`)
+        .set('Authorization', `Bearer ${token3}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(200);
+          done(err);
+        });
+    });
+
+    it('GET /users/documents should allow suppliers to retrieve documents', (done) => {
+      request(app)
+        .get(`${prefix}/users/documents`)
+        .set('Authorization', `Bearer ${token3}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(200);
+          done(err);
+        });
+    });
+
+    it('GET /documents/:id/download Download a documents', (done) => {
+      request(app)
+        .get(`${prefix}/documents/100/download`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(200);
+          done(err);
+        });
+    });
+
+    it('GET /documents/:id/download should throw an error when trying to download invalid file', (done) => {
+      request(app)
+        .get(`${prefix}/documents/102/download`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(500);
+          done(err);
+        });
+    });
+
+    it('DELETE /users/documents/:id Only the owner can delete a documents', (done) => {
+      request(app)
+        .delete(`${prefix}/users/documents/100`)
+        .set('Authorization', `Bearer ${token2}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(409);
+          done(err);
+        });
+    });
+
+    it('DELETE /users/documents/:id delete a documents', (done) => {
+      request(app)
+        .delete(`${prefix}/users/documents/100`)
+        .set('Authorization', `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(200);
+          done(err);
+        });
+    });
+
+
+    it('PATCH /documents/:id/verify Verify a documents', (done) => {
+      request(app)
+        .patch(`${prefix}/documents/2/verify`)
+        .set('Authorization', `Bearer ${token3}`)
+        .end((err, res) => {
+          expect(res.status)
+            .eql(200);
+          done(err);
+        });
+    });
+  });
+});

--- a/src/tests/units/middlewares/upload.test.js
+++ b/src/tests/units/middlewares/upload.test.js
@@ -14,9 +14,9 @@ describe('Unit tests file service', () => {
     done();
   });
 
-  it('Should upload an image when the image is not available', (done) => {
+  it('Should not upload an image when the image is not available', (done) => {
     const form = new FormData();
-    const parser = fileService.upload('small0');
+    const parser = fileService.upload('small0', 'images', 5);
 
     form.append('name', 'Multer');
     form.append('small0', file('small0.dat'));
@@ -29,7 +29,7 @@ describe('Unit tests file service', () => {
 
   it('Should upload an image when the image is available', (done) => {
     const form = new FormData();
-    const parser = fileService.upload('image');
+    const parser = fileService.upload('image', 'images', 5);
 
     form.append('name', 'Multer');
     form.append('image', file(resolve(__dirname, '../../mock-data/images/search.png')));

--- a/src/utils/schemas.js
+++ b/src/utils/schemas.js
@@ -151,6 +151,17 @@ const roomSchema = Joi.object().keys({
   allowUnknown: true
 });
 
+
+const documentSchema = Joi.object().keys({
+  name: Joi.string().required(),
+}).options({
+  abortEarly: false,
+  language: {
+    key: '{{key}} '
+  },
+  allowUnknown: false
+});
+
 const roleSchema = Joi.object().keys({
   email: Joi.string().strict().trim().email()
     .required(),
@@ -304,5 +315,6 @@ export default {
   '/hotels/:hotelId/rating': rateSchema,
   '/rating/:ratingId': updateRatingSchema,
   '/booking/request/:requestId': updateTripBookingSchema,
-  '/booking/payment': updateDirectBookingSchema
+  '/booking/payment': updateDirectBookingSchema,
+  '/users/documents': documentSchema,
 };


### PR DESCRIPTION
## What does this PR do?
Allow users to upload travel documents

#### Description of Task to be completed?
- [x] Implemented endpoint to add documents
- [x] Implemented endpoint to retrieve documents
- [x] Implemented endpoint to delete the document

#### How should this be manually tested?
- clone this repo and install dependencies
- run tests using `npm run pretest-travis  && npm test`
- start the server with `npm run watch` 
- Add document using `POST /users/documents`
- Get documents using `GET /users/documents`
- Download document using `GET /documents/:id/download`
- Login as travel admin then verify doc using `PATCH documents/:id/verify`
- Delete document using `DELETE users/documents/:id`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#171304386](https://www.pivotaltracker.com/story/show/171304386)

#### Screenshots (if appropriate)
Add document
![image](https://user-images.githubusercontent.com/15703806/75160232-55e81880-5722-11ea-8d88-c0436f9e2ba9.png)

Retrieve documents
![image](https://user-images.githubusercontent.com/15703806/75160358-862fb700-5722-11ea-8150-dd54362d3109.png)

Download document
![image](https://user-images.githubusercontent.com/15703806/75160516-cb53e900-5722-11ea-86bd-d5fde6d27517.png)


#### Questions:
N/A